### PR TITLE
Enable templating the password secret and write a proper README

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,39 +1,62 @@
-# Prerequisites 
+# Timescale Prometheus Helm chart
+
+This directory contains a Helm chart to deploy the Timescale Prometheus Connector
+on Kubernetes. This chart will do the following:
+
+* Create a Kubernetes Deployment (by default) with one pod
+  * The pod has a container created using the [Timescale Prometheus Connector Docker Image][docker-image] 
+* Create a Kubernetes Service exposing access to the Connector pods
+  * By default a LoadBalancer, but can be disabled to only a ClusterIP with a configurable port
+* Create a Kubernetes CronJob that deletes the data chunks that fall out of the retention period 
+
+## Prerequisites 
 
 The chart expects that the password used to connect to TimescaleDB is
-created before the chart is deployed.
-
-# What the chart deploys
-
-The chart will create:
-    - A Deployment for the prometheus-connector
-      - number of pods spawned can be controlled with `replicaCount`
-    - A Service for the adapter
-      - If `service.loadBalancer.enabled` is `true` an annotated LoadBalancer is created
-      - Otherwise a headless ClusterIP
-      - The port of the exposed service is controlled by `service.port`
-
-Upon installation the adapter will attempt to connect to the database (restarting itself if the db is not ready) 
-and execute the migration scripts.
-
-# Example configurations
-
-1. Connecting to an already deployed instance of TimescaleDB
-
-```
-connection:
-  passwordSecret: "name-of-secret-containing-the-password"
-  host:
-    nameTemplate: "service-of-db-created-in-the-other-release"
+created before the chart is deployed. 
+You can set the secret name by modifying the  `password.secretTemplate` value. 
+Templating is supported and you can use:
+```yaml
+password:
+  secretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
 ```
 
-2. Deploying this chart in the same release with TimescaleDB
+## Installing
 
-``` 
-connection:
-  passwordSecret: "name-of-secret-containing-the-password"
-  # no modification needed if no overrides specified for TimescaleDB deployment
-  # given here as example
-  host:
-    nameTemplate: "{{ .Release.Name }}.default.svc.cluster.local"
+To install the chart with the release name `my-release`:
+```shell script
+helm install --name my-release .
 ```
+
+You can override parameters using the `--set key=value[,key=value]` argument
+to `helm install`, e.g. to install the chart with specifying a previously created
+secret `timescale-secret` and an existing TimescaleDB instance:
+```shell script
+helm install --name my-release . \
+      --set connection.password.secretTemplate="timescale-secret"
+      --set connection.host.nameTemplate="timescaledb.default.svc.cluster.local"
+```
+
+Alternatively, a YAML file the specifies the values for the parameters can be provided
+while installing the chart. For example:
+```shell script
+helm install --name my-release -f myvalues.yaml .
+```
+
+## Configuration
+
+|       Parameter                   |           Description                       |               Default              |
+|-----------------------------------|---------------------------------------------|------------------------------------|
+| `image`                           | The image (with tag) to pull                | `timescale/timescale-prometheus`   |
+| `replicaCount`                    | Number of pods for the connector            | `1`                                |
+| `connection.user`                 | Username to connect to TimescaleDB with     | `postgres`                         |
+| `password.secretTemplate`         | The template for generating the name of a secret object which will hold the db password | `{{ .Release.Name }}-timescaledb-passwords` |
+| `host.nameTemplate`               | The template for generating the hostname of the db | `{{ .Release.Name }}.default.svc.cluster.local` |
+| `port`                            | Port the db listens to                      | `5432`                             |
+| `service.port`                    | Port the connector pods will accept connections on | `9201`                      |
+| `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
+| `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |
+| `dropChunk.schedule`              | The schedule with which the drop-chunk Job runs | `0,30 * * * *`                 |
+| `resources`                       | Requests and limits for each of the pods    | `{}`                               |
+| `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
+
+[docker-image]: https://hub.docker.com/timescale/timescale-prometheus

--- a/helm-chart/templates/cronjob-dropchunk.yaml
+++ b/helm-chart/templates/cronjob-dropchunk.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "0,30 * * * *"
+  schedule: {{ .Values.dropChunk.schedule }}
   jobTemplate:
     spec:
       template:
@@ -22,14 +22,14 @@ spec:
             - CALL prom.drop_chunks();
             env:
               - name: PGPORT
-                value: {{ .Values.port | quote }}
+                value: {{ .Values.connection.port | quote }}
               - name: PGUSER
-                value: {{ .Values.user }}
+                value: {{ .Values.connection.user }}
               - name: PGPASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.passwordSecret }}
-                    key: {{ .Values.user }}
+                    name: {{ tpl .Values.connection.password.secretTemplate . }}
+                    key: {{ .Values.connection.user }}
               - name: PGHOST
-                value: {{ tpl .Values.host.nameTemplate . }}
+                value: {{ tpl .Values.connection.host.nameTemplate . }}
           restartPolicy: OnFailure

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -36,7 +36,7 @@ spec:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.connection.passwordSecret }}
+                  name: {{ tpl .Values.connection.password.secretTemplate . }}
                   key: {{ .Values.connection.user }}
             - name: PGHOST
               value: {{ tpl .Values.connection.host.nameTemplate . }} 

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -5,14 +5,18 @@ replicaCount: 1
 connection:
   # user used to connect to TimescaleDB
   user: postgres
-  # the name of a Secret object containing the
-  # password to connect to TimescaleDB indexed
-  # by the user name
-  passwordSecret: "some-secret-name"
+  password:
+    # the template for generating the name of
+    # a Secret object containing the password to
+    # connect to TimescaleDB. The password should
+    # be indexed by the user name (connection.user)
+    secretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
   host:
-    # For a hardcoded host name from another release set:
+    # the template for generating the database host
+    # location
+    # for a hardcoded host name from another release, set:
     #   nameTemplate: "{{ already-deployed-timescale.default.svc.cluster.local }}"
-    # For a host name of a timescaledb instance
+    # for a host name of a timescaledb instance
     # deployed in the same release (without a cluster override) set:
     #   nameTemplate: "{{ .Release.Name }}".default.svc.cluster.local
     nameTemplate: "{{ .Release.Name }}.default.svc.cluster.local"
@@ -23,7 +27,7 @@ connection:
 service:
   port: 9201
   loadBalancer:
-    # If not enabled, we still expose the primary using a so called Headless Service
+    # If not enabled, we still expose the connector using a so called Headless Service
     # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
     enabled: true
     # Read more about the AWS annotations here:
@@ -35,6 +39,11 @@ service:
 
       # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
       # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
+
+# settings for the drop-chunk CronJob that deletes data outside of
+# the retention period
+dropChunk:
+  schedule: "0,30 * * * *"
 
 # set your own limits
 resources: {}


### PR DESCRIPTION
This PR updates the README to document all the configurable
values in the chart along with re-introducing templating for the
secret that should contain the db password.

The CronJob schedule is now also configurable.