### PR TITLE
Check that elements exist before casting.

### DIFF
--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -612,6 +612,9 @@ func (m *orderedMap) newPendingBuffer(metricTable string) *pendingBuffer {
 
 func (m *orderedMap) Front() (*list.Element, *pendingBuffer) {
 	elem := m.order.Front()
+	if elem == nil {
+		return nil, nil
+	}
 	return elem, elem.Value.(*pendingBuffer)
 }
 


### PR DESCRIPTION
This was missed in the switch from casting after retrieval to casting
during.