### PR TITLE
Update the flag names and default value of the dbname flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The Timescale-Prometheus Connector is a Go project managed by go modules. You ca
 any directory and on the first build it will download it's required dependencies.
 
 ```bash
-# Fetch the source code of Outflux in any directory
+# Fetch the source code of Timescale-Prometheus in any directory
 $ git clone git@github.com:timescale/timescale-prometheus.git
 $ cd ./timescale-prometheus
 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -11,13 +11,22 @@ on Kubernetes. This chart will do the following:
 
 ## Prerequisites 
 
-The chart expects that the password used to connect to TimescaleDB is
-created before the chart is deployed. 
-You can set the secret name by modifying the  `password.secretTemplate` value. 
+### Database Name
+
+The name of the database the Timescale-Prometheus connector will connect to by default
+is set to `timescale`. You can change it by modifying the `connection.dbName` value.
+The database **must be created before** starting the connector.
+
+### Password
+
+The chart expects that the password used to connect to TimescaleDB is stored in a 
+Kubernetes Secret created before the chart is deployed. 
+You can set the secret name by modifying the  `connection.password.secretTemplate` value. 
 Templating is supported and you can use:
 ```yaml
-password:
-  secretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
+connection:
+  password:
+    secretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
 ```
 
 ## Installing
@@ -49,9 +58,10 @@ helm install --name my-release -f myvalues.yaml .
 | `image`                           | The image (with tag) to pull                | `timescale/timescale-prometheus`   |
 | `replicaCount`                    | Number of pods for the connector            | `1`                                |
 | `connection.user`                 | Username to connect to TimescaleDB with     | `postgres`                         |
-| `password.secretTemplate`         | The template for generating the name of a secret object which will hold the db password | `{{ .Release.Name }}-timescaledb-passwords` |
-| `host.nameTemplate`               | The template for generating the hostname of the db | `{{ .Release.Name }}.{{ .Release.Namespace}}.svc.cluster.local` |
-| `port`                            | Port the db listens to                      | `5432`                             |
+| `connection.password.secretTemplate`         | The template for generating the name of a secret object which will hold the db password | `{{ .Release.Name }}-timescaledb-passwords` |
+| `connection.host.nameTemplate`               | The template for generating the hostname of the db | `{{ .Release.Name }}.{{ .Release.Namespace}}.svc.cluster.local` |
+| `connection.port`                 | Port the db listens to                      | `5432`                             |
+| `connection.dbName`               | Database name in TimescaleDB to connect to  | `timescale`                        |
 | `service.port`                    | Port the connector pods will accept connections on | `9201`                      |
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |

--- a/helm-chart/templates/cronjob-dropchunk.yaml
+++ b/helm-chart/templates/cronjob-dropchunk.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: {{ .Chart.Name }}-drop-chunk
-            image: postgres:11-alpine
+            image: postgres:12-alpine
             args:
             - psql
             - -c

--- a/helm-chart/templates/cronjob-dropchunk.yaml
+++ b/helm-chart/templates/cronjob-dropchunk.yaml
@@ -32,4 +32,6 @@ spec:
                     key: {{ .Values.connection.user }}
               - name: PGHOST
                 value: {{ tpl .Values.connection.host.nameTemplate . }}
+              - name:  PGDATABASE
+                value: {{ .Values.connection.dbName }}
           restartPolicy: OnFailure

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -29,25 +29,21 @@ spec:
             - containerPort: 9201
               name: connector-port
           env:
-            - name: PGPORT
+            - name: TS_PROM_DB_PORT
               value: {{ .Values.connection.port | quote }}
-            - name: PGUSER
+            - name: TS_PROM_DB_USER
               value: {{ .Values.connection.user }}
-            - name: PGPASSWORD
+            - name: TS_PROM_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ tpl .Values.connection.password.secretTemplate . }}
                   key: {{ .Values.connection.user }}
-            - name: PGHOST
-              value: {{ tpl .Values.connection.host.nameTemplate . }} 
-          args:
-            [
-              -pg-ssl-mode=require,
-              -pg-host=$(PGHOST),
-              -pg-user=$(PGUSER),
-              -pg-password=$(PGPASSWORD),
-              -pg-port=$(PGPORT)
-            ]
+            - name: TS_PROM_DB_HOST
+              value: {{ tpl .Values.connection.host.nameTemplate . }}
+            - name: TS_PROM_DB_NAME
+              value: {{ .Values.connection.dbName }}
+            - name: TS_PROM_DB_SSL_MODE
+              value: require
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -21,6 +21,10 @@ connection:
     #   nameTemplate: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
     nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
   port: 5432
+  # database name in which to store the metrics
+  # must be created before start
+  dbName: timescale
+
 
 # settings for the service to be created that will expose
 # the timescale-prometheus deployment

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -30,17 +30,17 @@ type Config struct {
 
 // ParseFlags parses the configuration flags specific to PostgreSQL and TimescaleDB
 func ParseFlags(cfg *Config) *Config {
-	flag.StringVar(&cfg.host, "pg-host", "localhost", "The PostgreSQL host")
-	flag.IntVar(&cfg.port, "pg-port", 5432, "The PostgreSQL port")
-	flag.StringVar(&cfg.user, "pg-user", "postgres", "The PostgreSQL user")
-	flag.StringVar(&cfg.password, "pg-password", "", "The PostgreSQL password")
-	flag.StringVar(&cfg.database, "pg-database", "postgres", "The PostgreSQL database")
-	flag.StringVar(&cfg.sslMode, "pg-ssl-mode", "disable", "The PostgreSQL connection ssl mode")
-	flag.IntVar(&cfg.dbConnectRetries, "pg-db-connect-retries", 0, "How many times to retry connecting to the database")
+	flag.StringVar(&cfg.host, "db-host", "localhost", "The TimescaleDB host")
+	flag.IntVar(&cfg.port, "db-port", 5432, "The TimescaleDB port")
+	flag.StringVar(&cfg.user, "db-user", "postgres", "The TimescaleDB user")
+	flag.StringVar(&cfg.password, "db-password", "", "The TimescaleDB password")
+	flag.StringVar(&cfg.database, "db-name", "timescale", "The TimescaleDB database")
+	flag.StringVar(&cfg.sslMode, "db-ssl-mode", "disable", "The TimescaleDB connection ssl mode")
+	flag.IntVar(&cfg.dbConnectRetries, "db-connect-retries", 0, "How many times to retry connecting to the database")
 	return cfg
 }
 
-// Client sends Prometheus samples to PostgreSQL
+// Client sends Prometheus samples to TimescaleDB
 type Client struct {
 	Connection    *pgxpool.Pool
 	ingestor      *pgmodel.DBIngestor


### PR DESCRIPTION
The flag names are changed to signify that the connector is no longer 
compatible with Postgres, just TimescaleDB.

Also the deployment in the helm-chart is simplified to use
the TS_PROM environment variables to set the connection
flags.

*Warning* Upon merging, the helm chart will require a new docker build to be uploaded to the docker hub because it assumes the new flag names