### PR TITLE
Add Go benchmarking for certain SQL functions

### DIFF
--- a/pkg/internal/testhelpers/containers_test.go
+++ b/pkg/internal/testhelpers/containers_test.go
@@ -46,7 +46,7 @@ func TestWithDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	WithDB(t, *database, func(db *pgxpool.Pool, t *testing.T, connectURL string) {
+	WithDB(t, *database, func(db *pgxpool.Pool, t testing.TB, connectURL string) {
 		var res int
 		err := db.QueryRow(context.Background(), "SELECT 1").Scan(&res)
 		if err != nil {

--- a/pkg/pgmodel/nan_test.go
+++ b/pkg/pgmodel/nan_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-func getSingleSampleValue(t *testing.T, resp *prompb.ReadResponse) float64 {
+func getSingleSampleValue(t testing.TB, resp *prompb.ReadResponse) float64 {
 	res := resp.GetResults()
 	if len(res) != 1 {
 		t.Fatal("Expect one result")
@@ -30,7 +30,7 @@ func getSingleSampleValue(t *testing.T, resp *prompb.ReadResponse) float64 {
 	return samples[0].GetValue()
 }
 
-func getBooleanSQLResult(t *testing.T, db *pgxpool.Pool, sql string, args ...interface{}) bool {
+func getBooleanSQLResult(t testing.TB, db *pgxpool.Pool, sql string, args ...interface{}) bool {
 	var res *bool
 	err := db.QueryRow(context.Background(), sql, args...).Scan(&res)
 	if err != nil {
@@ -47,7 +47,7 @@ func TestSQLStaleNaN(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	withDB(t, *database, func(db *pgxpool.Pool, t *testing.T) {
+	withDB(t, *database, func(db *pgxpool.Pool, t testing.TB) {
 		metricName := "StaleMetric"
 		metrics := []prompb.TimeSeries{
 			{

--- a/pkg/pgmodel/sql_bench_test.go
+++ b/pkg/pgmodel/sql_bench_test.go
@@ -1,0 +1,266 @@
+package pgmodel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+const (
+	labelCount      = 5
+	metricName      = "benchmark_metric"
+	otherMetricName = "other_benchmark_metric"
+)
+
+func BenchmarkGetSeriesIDForKeyValueArrayExistingSeries(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_1", func(db *pgxpool.Pool, t testing.TB) {
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkGetSeriesIDForKeyValueArrayNewSeriesExistingLabels(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_2", func(db *pgxpool.Pool, t testing.TB) {
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, otherMetricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkGetSeriesIDForKeyValueArrayNewSeriesNewLabels(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_3", func(db *pgxpool.Pool, t testing.TB) {
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkKeyValueArrayToLabelArrayCreateNewLabels(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_4", func(db *pgxpool.Pool, t testing.TB) {
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = keyValueArrayToLabelArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkKeyValueArrayToLabelArrayExistingLabels(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_5", func(db *pgxpool.Pool, t testing.TB) {
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = keyValueArrayToLabelArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkKeyValueArrayToLabelArrayCreateNewLabelKeys(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_6", func(db *pgxpool.Pool, t testing.TB) {
+
+		err := createMetricTableName(db, metricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = createMetricTableName(db, otherMetricName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, values := generateKeysAndValues(b.N+labelCount, "label")
+		for n := 0; n < b.N; n++ {
+			err = getSeriesIDForKeyValueArray(db, otherMetricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		keys, values = generateKeysAndValues(b.N+labelCount, "label_new")
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		for n := 0; n < b.N; n++ {
+			err = keyValueArrayToLabelArray(db, metricName, keys[n:n+labelCount], values[n:n+labelCount])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func BenchmarkGetOrCreateMetricTableName(b *testing.B) {
+	b.StopTimer()
+	withDB(b, "bench_7", func(db *pgxpool.Pool, t testing.TB) {
+		metricNames, _ := generateKeysAndValues(b.N, "metric")
+
+		var bench *testing.B
+		var ok bool
+		if bench, ok = t.(*testing.B); !ok {
+			t.Fatal("Not a benchmarking instance, stopping benchmark")
+		}
+
+		bench.ResetTimer()
+		bench.StartTimer()
+		var err error
+		for n := 0; n < b.N; n++ {
+			err = createMetricTableName(db, metricNames[n])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		bench.StopTimer()
+	})
+}
+
+func keyValueArrayToLabelArray(db *pgxpool.Pool, metricName string, keys []string, values []string) error {
+	var labelArray []int
+	return db.QueryRow(context.Background(), "SELECT prom.key_value_array_to_label_array($1, $2, $3)", metricName, keys, values).Scan(&labelArray)
+}
+
+func createMetricTableName(db *pgxpool.Pool, name string) error {
+	var metricID int
+	var tableName string
+	return db.QueryRow(context.Background(), "SELECT * FROM prom.get_or_create_metric_table_name($1)", name).Scan(&metricID, &tableName)
+}
+
+func getSeriesIDForKeyValueArray(db *pgxpool.Pool, metricName string, keys []string, values []string) error {
+	var seriesIDKeyVal int
+	return db.QueryRow(context.Background(), "SELECT prom.get_series_id_for_key_value_array($1, $2, $3)", metricName, keys, values).Scan(&seriesIDKeyVal)
+}
+
+func generateKeysAndValues(count int, prefix string) ([]string, []string) {
+	keys, values := make([]string, count), make([]string, count)
+
+	for i := 0; i < count; i++ {
+		keys[i] = fmt.Sprintf("%s_key_%d", prefix, i%labelCount)
+		values[i] = fmt.Sprintf("%s_value_%d", prefix, i)
+	}
+
+	return keys, values
+}

--- a/pkg/pgmodel/view_test.go
+++ b/pkg/pgmodel/view_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-func getViewRowCount(t *testing.T, db *pgxpool.Pool, view string, where string, expected int) {
+func getViewRowCount(t testing.TB, db *pgxpool.Pool, view string, where string, expected int) {
 	var count int
 	err := db.QueryRow(context.Background(), fmt.Sprintf("SELECT count(*) FROM %s %s", view, where)).Scan(&count)
 	if err != nil {
@@ -28,7 +28,7 @@ func TestSQLView(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	withDB(t, *database, func(db *pgxpool.Pool, t *testing.T) {
+	withDB(t, *database, func(db *pgxpool.Pool, t testing.TB) {
 		metrics := []prompb.TimeSeries{
 			{
 				Labels: []prompb.Label{
@@ -178,7 +178,7 @@ func TestSQLViewSelectors(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	withDB(t, *database, func(db *pgxpool.Pool, t *testing.T) {
+	withDB(t, *database, func(db *pgxpool.Pool, t testing.TB) {
 		metrics := []prompb.TimeSeries{
 			{
 				Labels: []prompb.Label{

--- a/pkg/util/election_test.go
+++ b/pkg/util/election_test.go
@@ -90,7 +90,7 @@ func TestRESTApi(t *testing.T) {
 }
 
 func TestPgAdvisoryLock(t *testing.T) {
-	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t *testing.T, connectURL string) {
+	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
 		lock, err := NewPgAdvisoryLock(1, connectURL)
 		if err != nil {
 			t.Fatal(err)
@@ -129,7 +129,7 @@ func TestPgAdvisoryLock(t *testing.T) {
 }
 
 func TestElector(t *testing.T) {
-	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t *testing.T, connectURL string) {
+	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
 		lock1, err := NewPgAdvisoryLock(2, connectURL)
 		if err != nil {
 			t.Error(err)
@@ -164,7 +164,7 @@ func TestElector(t *testing.T) {
 }
 
 func TestPrometheusLivenessCheck(t *testing.T) {
-	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t *testing.T, connectURL string) {
+	testhelpers.WithDB(t, *database, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
 		lock1, err := NewPgAdvisoryLock(3, connectURL)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Some of the SQL functions are suspected to be very performance
intensive. Adding the benchmark allows us to setup a baseline for future
performance testing.

Note: `BenchmarkKeyValueArrayToLabelArrayExistingLabels` fails to run, we need to take a look at it. I might have hit a bug with the benchmark.