### PR TITLE
Set query integration tests to read-only mode

### DIFF
--- a/pkg/internal/testhelpers/containers_test.go
+++ b/pkg/internal/testhelpers/containers_test.go
@@ -27,7 +27,7 @@ func TestPGConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	db, err := pgx.Connect(context.Background(), pgConnectURL(t, defaultDB))
+	db, err := pgx.Connect(context.Background(), pgConnectURL(defaultDB))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pgmodel/query_integration_test.go
+++ b/pkg/pgmodel/query_integration_test.go
@@ -511,8 +511,11 @@ func TestSQLQuery(t *testing.T) {
 	withDB(t, *database, func(db *pgxpool.Pool, t *testing.T) {
 		// Ingest test dataset.
 		ingestQueryTestDataset(db, t, generateSmallTimeseries())
+		// Getting a read-only connection to ensure read path is idempotent.
+		readOnly := testhelpers.GetReadOnlyConnection(t, *database)
+		defer readOnly.Close()
 
-		r := NewPgxReader(db)
+		r := NewPgxReader(readOnly)
 		for _, c := range testCases {
 			t.Run(c.name, func(t *testing.T) {
 				resp, err := r.Read(&c.readRequest)
@@ -879,8 +882,11 @@ func TestPromQL(t *testing.T) {
 	withDB(t, *database, func(db *pgxpool.Pool, t *testing.T) {
 		// Ingest test dataset.
 		ingestQueryTestDataset(db, t, generateLargeTimeseries())
+		// Getting a read-only connection to ensure read path is idempotent.
+		readOnly := testhelpers.GetReadOnlyConnection(t, *database)
+		defer readOnly.Close()
 
-		r := NewPgxReader(db)
+		r := NewPgxReader(readOnly)
 		for _, c := range testCases {
 			t.Run(c.name, func(t *testing.T) {
 				connResp, connErr := r.Read(c.readRequest)


### PR DESCRIPTION
Setting the read-only mode on the test database ensures we are not
writing to the database when executing queries.