### PR TITLE
Add custom logger to caching layer

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,6 +6,8 @@
 package log
 
 import (
+	"fmt"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/promlog"
@@ -51,4 +53,14 @@ func Warn(keyvals ...interface{}) {
 // Error logs an ERROR level message, ignoring logging errors
 func Error(keyvals ...interface{}) {
 	_ = level.Error(logger).Log(keyvals...)
+}
+
+// CustomCacheLogger is a custom logger used for transforming cache logs
+// so that they conform the our logging setup. It also implements the
+// bigcache.Logger interface.
+type CustomCacheLogger struct{}
+
+// Printf sends the log in the debug stream of the logger.
+func (c *CustomCacheLogger) Printf(format string, v ...interface{}) {
+	_ = level.Debug(logger).Log("msg", fmt.Sprintf(format, v...))
 }

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"runtime"
-	"time"
 
 	"github.com/allegro/bigcache"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -69,8 +68,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		return nil, err
 	}
 
-	config := bigcache.DefaultConfig(10 * time.Minute)
-	metrics, _ := bigcache.NewBigCache(config)
+	metrics, _ := bigcache.NewBigCache(pgmodel.DefaultCacheConfig())
 	cache := &pgmodel.MetricNameCache{Metrics: metrics}
 
 	ingestor := pgmodel.NewPgxIngestorWithMetricCache(connectionPool, cache)

--- a/pkg/pgmodel/bigcache.go
+++ b/pkg/pgmodel/bigcache.go
@@ -7,8 +7,14 @@ package pgmodel
 import (
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/allegro/bigcache"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+)
+
+const (
+	defaultEvictionDuration = 10 * time.Minute
 )
 
 var (
@@ -57,4 +63,11 @@ func (m *MetricNameCache) Get(metric string) (string, error) {
 // Set stores table name for specified metric.
 func (m *MetricNameCache) Set(metric string, tableName string) error {
 	return m.Metrics.Set(metric, []byte(tableName))
+}
+
+func DefaultCacheConfig() bigcache.Config {
+	config := bigcache.DefaultConfig(defaultEvictionDuration)
+	config.Logger = &log.CustomCacheLogger{}
+
+	return config
 }

--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -37,9 +37,8 @@ const (
 )
 
 var (
-	copyColumns           = []string{"time", "value", "series_id"}
-	errMissingTableName   = fmt.Errorf("missing metric table name")
-	errInvalidLabelsValue = func(s string) error { return fmt.Errorf("invalid labels value %s", s) }
+	copyColumns         = []string{"time", "value", "series_id"}
+	errMissingTableName = fmt.Errorf("missing metric table name")
 )
 
 type pgxBatch interface {
@@ -166,8 +165,7 @@ func NewPgxIngestorWithMetricCache(c *pgxpool.Pool, cache MetricCache) *DBIngest
 
 	pi := newPgxInserter(conn, cache)
 
-	config := bigcache.DefaultConfig(10 * time.Minute)
-	series, _ := bigcache.NewBigCache(config)
+	series, _ := bigcache.NewBigCache(DefaultCacheConfig())
 
 	bc := &bCache{
 		series: series,
@@ -181,8 +179,7 @@ func NewPgxIngestorWithMetricCache(c *pgxpool.Pool, cache MetricCache) *DBIngest
 
 // NewPgxIngestor returns a new Ingestor that write to PostgreSQL using PGX
 func NewPgxIngestor(c *pgxpool.Pool) *DBIngestor {
-	config := bigcache.DefaultConfig(10 * time.Minute)
-	metrics, _ := bigcache.NewBigCache(config)
+	metrics, _ := bigcache.NewBigCache(DefaultCacheConfig())
 	cache := &MetricNameCache{metrics}
 	return NewPgxIngestorWithMetricCache(c, cache)
 }
@@ -650,8 +647,7 @@ func NewPgxReaderWithMetricCache(c *pgxpool.Pool, cache MetricCache) *DBReader {
 
 // NewPgxReader returns a new DBReader that reads that from PostgreSQL using PGX.
 func NewPgxReader(c *pgxpool.Pool) *DBReader {
-	config := bigcache.DefaultConfig(10 * time.Minute)
-	metrics, _ := bigcache.NewBigCache(config)
+	metrics, _ := bigcache.NewBigCache(DefaultCacheConfig())
 	cache := &MetricNameCache{metrics}
 	return NewPgxReaderWithMetricCache(c, cache)
 }


### PR DESCRIPTION
Default caching logger would output logs to standard output which did not conform
to our logging library output standards. This commit adds a custom logger which
transforms that output to match our logger.

Closes #52 