### PR TITLE
Added Prometheus annotations to Helm chart

### DIFF
--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
         app: {{ template "connector.fullname" . }}
+      {{ if .Values.prometheus.enabled }}
+      annotations: {{ .Values.prometheus.annotations | toYaml | nindent 8 }}
+      {{ end }}
     spec:
       containers:
         - image: {{ .Values.image }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -25,6 +25,16 @@ connection:
   # must be created before start
   dbName: timescale
 
+# Prometheus annotations to configure scraping metrics from the connector
+prometheus:
+  enabled: true
+  # Using the predefined annotations from the Prometheus helm chart:
+  # https://hub.helm.sh/charts/stable/prometheus
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9201'
+    prometheus.io/path: '/metrics'
+
 
 # settings for the service to be created that will expose
 # the timescale-prometheus deployment


### PR DESCRIPTION
Annotations predefined by the Prometheus Helm chart (https://hub.helm.sh/charts/stable/prometheus)
are needed in the pod annotations so that the Prometheus service discovery works properly with
the connector and scrapes up its metrics endpoint.