### PR TITLE
Add Prometheus namespace and register missing metrics

### DIFF
--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -49,64 +49,74 @@ type config struct {
 const (
 	tickInterval      = time.Second
 	promLivenessCheck = time.Second
+	promNamespace     = "ts_prom"
 )
 
 var (
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "current_leader",
-			Help: "Shows current election leader status",
+			Namespace: promNamespace,
+			Name:      "current_leader",
+			Help:      "Shows current election leader status",
 		},
 	)
 	receivedSamples = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "received_samples_total",
-			Help: "Total number of received samples.",
+			Namespace: promNamespace,
+			Name:      "received_samples_total",
+			Help:      "Total number of received samples.",
 		},
 	)
 	receivedQueries = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "received_queries_total",
-			Help: "Total number of received queries.",
+			Namespace: promNamespace,
+			Name:      "received_queries_total",
+			Help:      "Total number of received queries.",
 		},
 	)
 	sentSamples = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "sent_samples_total",
-			Help: "Total number of processed samples sent to remote storage.",
+			Namespace: promNamespace,
+			Name:      "sent_samples_total",
+			Help:      "Total number of processed samples sent to remote storage.",
 		},
 	)
 	failedSamples = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "failed_samples_total",
-			Help: "Total number of processed samples which failed on send to remote storage.",
+			Namespace: promNamespace,
+			Name:      "failed_samples_total",
+			Help:      "Total number of processed samples which failed on send to remote storage.",
 		},
 	)
 	failedQueries = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "failed_queries_total",
-			Help: "Total number of queries which failed on send to remote storage.",
+			Namespace: promNamespace,
+			Name:      "failed_queries_total",
+			Help:      "Total number of queries which failed on send to remote storage.",
 		},
 	)
 	sentBatchDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "sent_batch_duration_seconds",
-			Help:    "Duration of sample batch send calls to the remote storage.",
-			Buckets: prometheus.DefBuckets,
+			Namespace: promNamespace,
+			Name:      "sent_batch_duration_seconds",
+			Help:      "Duration of sample batch send calls to the remote storage.",
+			Buckets:   prometheus.DefBuckets,
 		},
 	)
 	queryBatchDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "query_batch_duration_seconds",
-			Help:    "Duration of query batch read calls to the remote storage.",
-			Buckets: prometheus.DefBuckets,
+			Namespace: promNamespace,
+			Name:      "query_batch_duration_seconds",
+			Help:      "Duration of query batch read calls to the remote storage.",
+			Buckets:   prometheus.DefBuckets,
 		},
 	)
 	httpRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_request_duration_ms",
-			Help:    "Duration of HTTP request in milliseconds",
-			Buckets: prometheus.DefBuckets,
+			Namespace: promNamespace,
+			Name:      "http_request_duration_ms",
+			Help:      "Duration of HTTP request in milliseconds",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"path"},
 	)

--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -128,9 +128,12 @@ var (
 func init() {
 	prometheus.MustRegister(leaderGauge)
 	prometheus.MustRegister(receivedSamples)
+	prometheus.MustRegister(receivedQueries)
 	prometheus.MustRegister(sentSamples)
 	prometheus.MustRegister(failedSamples)
+	prometheus.MustRegister(failedQueries)
 	prometheus.MustRegister(sentBatchDuration)
+	prometheus.MustRegister(queryBatchDuration)
 	prometheus.MustRegister(httpRequestDuration)
 	writeThroughput.Start()
 }


### PR DESCRIPTION
Adding a namespace will give our fully qualified metric names a prefix so they don't look so generic.

For example, `current_leader` will turn into `ts_prom_current_leader`.

This PR also registers already defined query path metrics.