### PR TITLE
Add Prerequisite check for timescale-prometheus-extra

### DIFF
--- a/extension/Readme.md
+++ b/extension/Readme.md
@@ -12,4 +12,4 @@ The extension is installed by default on the
 
 To compile and install from source run: `make && make install`.
 
-This extension will be installed automatically by the timescale-prometheus connector.
+This extension will be created via `CREATE EXTENSION` automatically by the timescale-prometheus connector and should not be created manually.

--- a/extension/sql/timescale-prometheus.sql
+++ b/extension/sql/timescale-prometheus.sql
@@ -1,4 +1,25 @@
 
+DO $$
+    DECLARE
+        version INT;
+        dirty BOOLEAN;
+    BEGIN
+        BEGIN
+            SELECT version, dirty
+            INTO STRICT version, dirty
+            FROM public.prom_schema_migrations;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE EXCEPTION 'could not determine the version of the timescale-prometheus connector that was installed'
+            USING HINT='This extension should not be created manually. It will be created by the timescale-prometheus connector and requires the connector to be installed first.';
+            RETURN;
+
+        IF version < 1 OR DIRTY THEN
+            RAISE EXCEPTION 'the requisite version of the timescale-prometheus connector has not been installed'
+            USING HINT='This extension should not be created manually. It will be created by the timescale-prometheus connector and requires the connector to be installed first.';
+        END IF;
+    END
+$$;
+
 SET LOCAL search_path TO DEFAULT;
 
 CREATE OR REPLACE FUNCTION @extschema@.const_support(internal) RETURNS INTERNAL


### PR DESCRIPTION
The extension requires that the schema for timescale-prometheus
connector installed and the migration is run. We add a check so
that the extension let's people know if something is wrong.