### PR TITLE
Fix support function to work with operators

### DIFF
--- a/extension/sql/timescale-prometheus.sql
+++ b/extension/sql/timescale-prometheus.sql
@@ -58,10 +58,10 @@ DO $$
     END
 $$;
 
-CREATE OR REPLACE FUNCTION @extschema@.const_support(internal) RETURNS INTERNAL
-AS '$libdir/timescale_prometheus_extra', 'const_support'
+CREATE OR REPLACE FUNCTION @extschema@.make_call_subquery_support(internal) RETURNS INTERNAL
+AS '$libdir/timescale_prometheus_extra', 'make_call_subquery_support'
 LANGUAGE C IMMUTABLE STRICT;
-GRANT EXECUTE ON FUNCTION @extschema@.const_support(internal) TO prom_reader;
+GRANT EXECUTE ON FUNCTION @extschema@.make_call_subquery_support(internal) TO prom_reader;
 
 
 --wrapper around jsonb_each_text to give a better row_estimate
@@ -91,7 +91,7 @@ AS $func$
     WHERE l.key = key and l.value = pat
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE
-SUPPORT @extschema@.const_support;
+SUPPORT @extschema@.make_call_subquery_support;
 GRANT EXECUTE ON FUNCTION @extschema@.label_find_key_equal(label_key, pattern) TO prom_reader;
 
 CREATE OR REPLACE FUNCTION @extschema@.label_find_key_not_equal(key label_key, pat pattern)
@@ -102,7 +102,7 @@ AS $func$
     WHERE l.key = key and l.value = pat
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE
-SUPPORT @extschema@.const_support;
+SUPPORT @extschema@.make_call_subquery_support;
 GRANT EXECUTE ON FUNCTION @extschema@.label_find_key_not_equal(label_key, pattern) TO prom_reader;
 
 CREATE OR REPLACE FUNCTION @extschema@.label_find_key_regex(key label_key, pat pattern)
@@ -113,7 +113,7 @@ AS $func$
     WHERE l.key = key and l.value ~ pat
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE
-SUPPORT @extschema@.const_support;
+SUPPORT @extschema@.make_call_subquery_support;
 GRANT EXECUTE ON FUNCTION @extschema@.label_find_key_regex(label_key, pattern) TO prom_reader;
 
 CREATE OR REPLACE FUNCTION @extschema@.label_find_key_not_regex(key label_key, pat pattern)
@@ -124,7 +124,7 @@ AS $func$
     WHERE l.key = key and l.value ~ pat
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE
-SUPPORT @extschema@.const_support;
+SUPPORT @extschema@.make_call_subquery_support;
 GRANT EXECUTE ON FUNCTION @extschema@.label_find_key_not_regex(label_key, pattern) TO prom_reader;
 
 CREATE OPERATOR @extschema@.== (

--- a/extension/src/support.c
+++ b/extension/src/support.c
@@ -15,18 +15,18 @@
 PG_MODULE_MAGIC;
 #endif
 
-PG_FUNCTION_INFO_V1(const_support);
+PG_FUNCTION_INFO_V1(make_call_subquery_support);
 /*
  * This is a support function that optimizes calls to the supported function if
- * it's called with constant arguments. Such calls are transformed into a
- * subselect of the function call. This allows the planner to make this call
+ * it's called with constant-like arguments. Such calls are transformed into a
+ * subquery of the function call. This allows the planner to make this call
  * an InitPlan which is evaluated once per query instead of multiple times
  * (e.g. on every tuple when the function is used in a WHERE clause).
- * This should be used on any stable function that is often called with constant
+ * This should be used on any stable function that is often called with constant-like
  * arguments.
 */
 Datum
-const_support(PG_FUNCTION_ARGS)
+make_call_subquery_support(PG_FUNCTION_ARGS)
 {
 	Node	   *rawreq = (Node *) PG_GETARG_POINTER(0);
 	Node	   *ret = NULL;


### PR DESCRIPTION
Previously a support function only optimized function calls
on consts but the operator logic inserts a CoerceToDomain
node before the const as well. This PR allows this case to
also be handled by relaxing the constrainst on args from having
to be constants to having to be merely const-like. That is
the expression cannot reference any vars or use volatile functions.