### PR TITLE
Make migrations idempotent

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,4 +1,4 @@
 name: timescale-prometheus
-version: 0.1.0-alpha.2
+version: 0.1.0-alpha.3
 apiVersion: v2
 description: Timescale Prometheus Connector deployment

--- a/pkg/pgmodel/end_to_end_tests/migrate_test.go
+++ b/pkg/pgmodel/end_to_end_tests/migrate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/timescale/timescale-prometheus/pkg/internal/testhelpers"
 )
 
 const (
@@ -32,5 +33,15 @@ func TestMigrate(t *testing.T) {
 			t.Error("Dirty is true")
 		}
 
+	})
+}
+
+func TestMigrateTwice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(db *pgxpool.Pool, t testing.TB, connectURL string) {
+		performMigrate(t, *testDatabase, connectURL)
+		performMigrate(t, *testDatabase, connectURL)
 	})
 }


### PR DESCRIPTION
Previously migrations failed if they were run on an already migrated database.
This made the connector fail if it was ever restarted.