### PR TITLE
Fix the cronjob call

### DIFF
--- a/helm-chart/templates/cronjob-dropchunk.yaml
+++ b/helm-chart/templates/cronjob-dropchunk.yaml
@@ -19,7 +19,7 @@ spec:
             args:
             - psql
             - -c
-            - CALL prom.drop_chunks();
+            - CALL prom_api.drop_chunks();
             env:
               - name: PGPORT
                 value: {{ .Values.connection.port | quote }}


### PR DESCRIPTION
The `prom` schema does not exist anymore. It is replaced by `prom_api`.
cf. Issue #83  for more context.