### PR TITLE
Add version const and print on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN apk update && apk add --no-cache git \
     && cd timescale-prometheus \
     && go mod download \
     && GIT_COMMIT=$(git rev-list -1 HEAD) \
-    && CGO_ENABLED=0 go build -a --ldflags '-w' --ldflags "-X main.CommitHash=$GIT_COMMIT" -o /go/timescale-prometheus ./cmd/timescale-prometheus
+    && VERSION=$(git describe $GIT_COMMIT) \
+    && CGO_ENABLED=0 go build -a \
+    --ldflags '-w' --ldflags "-X main.CommitHash=$GIT_COMMIT" --ldflags "-X main.Version=$VERSION" \
+    -o /go/timescale-prometheus ./cmd/timescale-prometheus
 
 # Final image
 FROM busybox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # Build stage
 FROM golang:1.14.1-alpine AS builder
-COPY ./pkg timescale-prometheus-connector/pkg
-COPY ./cmd timescale-prometheus-connector/cmd
-COPY ./go.mod timescale-prometheus-connector/go.mod
-COPY ./go.sum timescale-prometheus-connector/go.sum
+COPY ./.git timescale-prometheus/.git
+COPY ./pkg timescale-prometheus/pkg
+COPY ./cmd timescale-prometheus/cmd
+COPY ./go.mod timescale-prometheus/go.mod
+COPY ./go.sum timescale-prometheus/go.sum
 RUN apk update && apk add --no-cache git \
-    && cd timescale-prometheus-connector \
+    && cd timescale-prometheus \
     && go mod download \
-    && CGO_ENABLED=0 go build -a --ldflags '-w' -o /go/timescale-prometheus ./cmd/timescale-prometheus
+    && GIT_COMMIT=$(git rev-list -1 HEAD) \
+    && CGO_ENABLED=0 go build -a --ldflags '-w' --ldflags "-X main.CommitHash=$GIT_COMMIT" -o /go/timescale-prometheus ./cmd/timescale-prometheus
 
 # Final image
 FROM busybox

--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -142,17 +142,19 @@ func main() {
 	cfg := parseFlags()
 	err := log.Init(cfg.logLevel)
 	if err != nil {
+		fmt.Println("Version: ", Version, "Commit Hash: ", CommitHash)
 		fmt.Println("Fatal error: cannot start logger", err)
 		os.Exit(1)
 	}
+	log.Info("msg", "Version:"+Version+"; Commit Hash: "+CommitHash)
 	log.Info("config", util.MaskPassword(fmt.Sprintf("%+v", cfg)))
-
 	http.Handle(cfg.telemetryPath, promhttp.Handler())
 
 	elector, err = initElector(cfg)
 
 	if err != nil {
-		log.Error("msg", "Aborting startup because of elector init error: %s", util.MaskPassword(err.Error()))
+		errStr := fmt.Sprintf("Aborting startup because of elector init error: %s", util.MaskPassword(err.Error()))
+		log.Error("msg", errStr)
 		os.Exit(1)
 	}
 

--- a/cmd/timescale-prometheus/version_info.go
+++ b/cmd/timescale-prometheus/version_info.go
@@ -1,0 +1,6 @@
+package main
+
+var (
+	Version    = "0.1.0-dev"
+	CommitHash = ""
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - 9090:9090/tcp
     volumes:
     - ./sample-docker-prometheus.yml:/etc/prometheus/prometheus.yml:ro
-  prometheus_postgresql_adapter:
+  timescale-prometheus-connector:
     build:
       context: .
     depends_on:

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -8,31 +8,34 @@ package log
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/common/promlog"
 )
 
 var (
 	// Application wide logger
 	logger log.Logger
+
+	// logger timestamp format
+	timestampFormat = log.TimestampFormat(
+		func() time.Time { return time.Now().UTC() },
+		"2006-01-02T15:04:05.000Z07:00",
+	)
 )
 
 // Init starts logging given the minimum log level
 func Init(logLevel string) error {
-	allowedLevel := promlog.AllowedLevel{}
-	err := allowedLevel.Set(logLevel)
+	var l log.Logger
+	l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	logLevelOption, err := parseLogLevel(logLevel)
 	if err != nil {
 		return err
 	}
 
-	config := promlog.Config{
-		Level:  &allowedLevel,
-		Format: &promlog.AllowedFormat{},
-	}
-
-	logger = promlog.New(&config)
+	l = level.NewFilter(l, logLevelOption)
+	logger = log.With(l, "ts", timestampFormat, "caller", log.Caller(4))
 	return nil
 }
 
@@ -70,4 +73,19 @@ type CustomCacheLogger struct{}
 // Printf sends the log in the debug stream of the logger.
 func (c *CustomCacheLogger) Printf(format string, v ...interface{}) {
 	_ = level.Debug(logger).Log("msg", fmt.Sprintf(format, v...))
+}
+
+func parseLogLevel(logLevel string) (level.Option, error) {
+	switch logLevel {
+	case "debug":
+		return level.AllowDebug(), nil
+	case "info":
+		return level.AllowInfo(), nil
+	case "warn":
+		return level.AllowWarn(), nil
+	case "error":
+		return level.AllowError(), nil
+	default:
+		return nil, fmt.Errorf("unrecognized log level %q", logLevel)
+	}
 }

--- a/pkg/util/lock.go
+++ b/pkg/util/lock.go
@@ -154,6 +154,8 @@ func (l *PgAdvisoryLock) connCleanUp() {
 
 //Close cleans up the connection
 func (l *PgAdvisoryLock) Close() {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
 	l.connCleanUp()
 }
 


### PR DESCRIPTION
When debugging issues that users are facing we need to know
which version they are using. Especially in container environments 
because of stale :latest images.