### PR TITLE
Take into account ErrNoChange returned from pkg migrate

### DIFF
--- a/pkg/pgmodel/migrate.go
+++ b/pkg/pgmodel/migrate.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	timescaleInstall = "CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public;"
-	extensionInstall = "CREATE EXTENSION timescale_prometheus_extra WITH SCHEMA %s;"
+	extensionInstall = "CREATE EXTENSION IF NOT EXISTS timescale_prometheus_extra WITH SCHEMA %s;"
 )
 
 type mySrc struct {
@@ -96,6 +96,11 @@ func Migrate(db *sql.DB) error {
 	}
 
 	err = m.Up()
+	if err == migrate.ErrNoChange {
+		log.Info("msg", "No migration changes!")
+		err = nil
+	}
+
 	if err == nil {
 		_, extErr := db.Exec(fmt.Sprintf(extensionInstall, extSchema))
 		if extErr != nil {


### PR DESCRIPTION
The migrate package uses ErrNoChange to signal that
no changes were migrations were applied because
the database was up to date. We didn't check this
case and it made it impossible to restart the connector.

Branch was made from 0.1.0-alpha.3 release, we should issue a patch to the release before rebasing this on the current master