### PR TITLE
Reduce memory usage on ingest

### DIFF
--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -317,14 +317,14 @@ func write(writer pgmodel.DBInserter) http.Handler {
 			return
 		}
 
-		ctx := pgmodel.NewInsertCtx()
-		if err := proto.Unmarshal(reqBuf, &ctx.WriteRequest); err != nil {
+		req := pgmodel.NewWriteRequest()
+		if err := proto.Unmarshal(reqBuf, req); err != nil {
 			log.Error("msg", "Unmarshal error", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		ts := ctx.WriteRequest.GetTimeseries()
+		ts := req.GetTimeseries()
 		receivedBatchCount := 0
 
 		for _, t := range ts {
@@ -334,7 +334,7 @@ func write(writer pgmodel.DBInserter) http.Handler {
 		receivedSamples.Add(float64(receivedBatchCount))
 		begin := time.Now()
 
-		numSamples, err := writer.Ingest(ctx.WriteRequest.GetTimeseries(), ctx)
+		numSamples, err := writer.Ingest(req.GetTimeseries(), req)
 		if err != nil {
 			log.Warn("msg", "Error sending samples to remote storage", "err", err, "num_samples", numSamples)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -350,8 +350,8 @@ func write(writer pgmodel.DBInserter) http.Handler {
 		writeThroughput.SetCurrent(getCounterValue(sentSamples))
 
 		select {
-		case d := <-writeThroughput.Values:
-			log.Info("msg", "Samples write throughput", "samples/sec", d)
+		case _ = <-writeThroughput.Values:
+			// log.Info("msg", "Samples write throughput", "samples/sec", d)
 		default:
 		}
 

--- a/cmd/timescale-prometheus/main_test.go
+++ b/cmd/timescale-prometheus/main_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"github.com/timescale/timescale-prometheus/pkg/pgmodel"
 	"github.com/timescale/timescale-prometheus/pkg/prompb"
 
 	"github.com/timescale/timescale-prometheus/pkg/log"
@@ -112,7 +111,7 @@ type mockInserter struct {
 	err    error
 }
 
-func (m *mockInserter) Ingest(ts []prompb.TimeSeries, ctx *pgmodel.InsertCtx) (uint64, error) {
+func (m *mockInserter) Ingest(ts []prompb.TimeSeries, ctx *prompb.WriteRequest) (uint64, error) {
 	m.ts = ts
 	return m.result, m.err
 }

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -25,6 +25,8 @@ type Config struct {
 	database         string
 	sslMode          string
 	dbConnectRetries int
+	asyncAcks        bool
+	reportInterval   int
 }
 
 // ParseFlags parses the configuration flags specific to PostgreSQL and TimescaleDB
@@ -36,6 +38,8 @@ func ParseFlags(cfg *Config) *Config {
 	flag.StringVar(&cfg.database, "db-name", "timescale", "The TimescaleDB database")
 	flag.StringVar(&cfg.sslMode, "db-ssl-mode", "disable", "The TimescaleDB connection ssl mode")
 	flag.IntVar(&cfg.dbConnectRetries, "db-connect-retries", 0, "How many times to retry connecting to the database")
+	flag.BoolVar(&cfg.asyncAcks, "async-acks", false, "Ack before data is written to DB")
+	flag.IntVar(&cfg.reportInterval, "tput-report", 0, "interval in seconds at which throughput should be reported")
 	return cfg
 }
 
@@ -71,7 +75,8 @@ func NewClient(cfg *Config) (*Client, error) {
 	metrics, _ := bigcache.NewBigCache(pgmodel.DefaultCacheConfig())
 	cache := &pgmodel.MetricNameCache{Metrics: metrics}
 
-	ingestor, err := pgmodel.NewPgxIngestorWithMetricCache(connectionPool, cache)
+	c := pgmodel.Cfg{AsyncAcks: cfg.asyncAcks, ReportInterval: cfg.reportInterval}
+	ingestor, err := pgmodel.NewPgxIngestorWithMetricCache(connectionPool, cache, &c)
 	if err != nil {
 		log.Error("err starting ingestor", err)
 		return nil, err
@@ -93,8 +98,8 @@ func (c *Client) Close() {
 }
 
 // Ingest writes the timeseries object into the DB
-func (c *Client) Ingest(tts []prompb.TimeSeries, ctx *pgmodel.InsertCtx) (uint64, error) {
-	return c.ingestor.Ingest(tts, ctx)
+func (c *Client) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
+	return c.ingestor.Ingest(tts, req)
 }
 
 // Read returns the promQL query results

--- a/pkg/pgmodel/bigcache.go
+++ b/pkg/pgmodel/bigcache.go
@@ -7,6 +7,7 @@ package pgmodel
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/allegro/bigcache"
@@ -62,7 +63,13 @@ func (m *MetricNameCache) Get(metric string) (string, error) {
 
 // Set stores table name for specified metric.
 func (m *MetricNameCache) Set(metric string, tableName string) error {
-	return m.Metrics.Set(metric, []byte(tableName))
+	// deep copy the strings so the original memory doesn't need to stick around
+	metricBuilder := strings.Builder{}
+	metricBuilder.Grow(len(metric))
+	metricBuilder.WriteString(metric)
+	table := make([]byte, len(tableName))
+	copy(table, tableName)
+	return m.Metrics.Set(metricBuilder.String(), table)
 }
 
 func DefaultCacheConfig() bigcache.Config {

--- a/pkg/pgmodel/end_to_end_tests/concurrent_sql_test.go
+++ b/pkg/pgmodel/end_to_end_tests/concurrent_sql_test.go
@@ -195,7 +195,7 @@ func testConcurrentInsertSimple(t testing.TB, db *pgxpool.Pool, metric string) {
 		t.Fatal(err)
 	}
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(metrics, NewInsertCtx())
+	_, err = ingestor.Ingest(metrics, NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func testConcurrentInsertAdvanced(t testing.TB, db *pgxpool.Pool) {
 		t.Fatal(err)
 	}
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(metrics, NewInsertCtx())
+	_, err = ingestor.Ingest(metrics, NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pgmodel/end_to_end_tests/create_test.go
+++ b/pkg/pgmodel/end_to_end_tests/create_test.go
@@ -156,7 +156,7 @@ func TestSQLChunkInterval(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewInsertCtx())
+		_, err = ingestor.Ingest(ts, NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -396,7 +396,7 @@ func TestSQLIngest(t *testing.T) {
 					t.Fatal(err)
 				}
 				defer ingestor.Close()
-				cnt, err := ingestor.Ingest(tcase.metrics, NewInsertCtx())
+				cnt, err := ingestor.Ingest(tcase.metrics, NewWriteRequest())
 				if err != nil && err != tcase.expectErr {
 					t.Fatalf("got an unexpected error %v", err)
 				}

--- a/pkg/pgmodel/end_to_end_tests/drop_test.go
+++ b/pkg/pgmodel/end_to_end_tests/drop_test.go
@@ -49,7 +49,7 @@ func TestSQLRetentionPeriod(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewInsertCtx())
+		_, err = ingestor.Ingest(ts, NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestSQLDropChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewInsertCtx())
+		_, err = ingestor.Ingest(ts, NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -232,7 +232,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewInsertCtx())
+		_, err = ingestor.Ingest(ts, NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/pgmodel/end_to_end_tests/nan_test.go
+++ b/pkg/pgmodel/end_to_end_tests/nan_test.go
@@ -73,7 +73,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewInsertCtx())
+		_, err = ingestor.Ingest(metrics, NewWriteRequest())
 
 		if err != nil {
 			t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/pgmodel/end_to_end_tests/query_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/query_integration_test.go
@@ -554,7 +554,7 @@ func ingestQueryTestDataset(db *pgxpool.Pool, t testing.TB, metrics []prompb.Tim
 	if err != nil {
 		t.Fatal(err)
 	}
-	cnt, err := ingestor.Ingest(metrics, NewInsertCtx())
+	cnt, err := ingestor.Ingest(metrics, NewWriteRequest())
 
 	if err != nil {
 		t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/pgmodel/end_to_end_tests/view_test.go
+++ b/pkg/pgmodel/end_to_end_tests/view_test.go
@@ -149,7 +149,7 @@ func TestSQLView(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewInsertCtx())
+		_, err = ingestor.Ingest(metrics, NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)
@@ -247,7 +247,7 @@ func TestSQLViewSelectors(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewInsertCtx())
+		_, err = ingestor.Ingest(metrics, NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/pgmodel/ingestor.go
+++ b/pkg/pgmodel/ingestor.go
@@ -24,7 +24,7 @@ type SeriesID int64
 
 // inserter is responsible for inserting label, series and data into the storage.
 type inserter interface {
-	InsertNewData(rows map[string][]samplesInfo, ctx *InsertCtx) (uint64, error)
+	InsertNewData(rows map[string][]samplesInfo) (uint64, error)
 	CompleteMetricCreation() error
 	Close()
 }
@@ -41,7 +41,7 @@ type Cache interface {
 }
 
 type samplesInfo struct {
-	labels   Labels
+	labels   *Labels
 	seriesID SeriesID
 	samples  []prompb.Sample
 }
@@ -53,14 +53,14 @@ type DBIngestor struct {
 }
 
 // Ingest transforms and ingests the timeseries data into Timescale database.
-func (i *DBIngestor) Ingest(tts []prompb.TimeSeries, ctx *InsertCtx) (uint64, error) {
-	data, totalRows, err := i.parseData(tts, ctx)
+func (i *DBIngestor) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
+	data, totalRows, err := i.parseData(tts, req)
 
 	if err != nil {
 		return 0, err
 	}
 
-	rowsInserted, err := i.db.InsertNewData(data, ctx)
+	rowsInserted, err := i.db.InsertNewData(data)
 	if err == nil && int(rowsInserted) != totalRows {
 		return rowsInserted, fmt.Errorf("Failed to insert all the data! Expected: %d, Got: %d", totalRows, rowsInserted)
 	}
@@ -71,7 +71,7 @@ func (i *DBIngestor) CompleteMetricCreation() error {
 	return i.db.CompleteMetricCreation()
 }
 
-func (i *DBIngestor) parseData(tts []prompb.TimeSeries, ctx *InsertCtx) (map[string][]samplesInfo, int, error) {
+func (i *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.WriteRequest) (map[string][]samplesInfo, int, error) {
 	dataSamples := make(map[string][]samplesInfo)
 	rows := 0
 
@@ -80,7 +80,7 @@ func (i *DBIngestor) parseData(tts []prompb.TimeSeries, ctx *InsertCtx) (map[str
 			continue
 		}
 
-		seriesLabels, metricName, err := labelProtosToLabels(t.Labels, ctx)
+		seriesLabels, metricName, err := labelProtosToLabels(t.Labels)
 		if err != nil {
 			return nil, rows, err
 		}
@@ -96,6 +96,8 @@ func (i *DBIngestor) parseData(tts []prompb.TimeSeries, ctx *InsertCtx) (map[str
 
 		dataSamples[metricName] = append(dataSamples[metricName], sample)
 	}
+
+	FinishWriteRequest(req)
 
 	return dataSamples, rows, nil
 }

--- a/pkg/pgmodel/ingestor_interface.go
+++ b/pkg/pgmodel/ingestor_interface.go
@@ -11,5 +11,5 @@ import "github.com/timescale/timescale-prometheus/pkg/prompb"
 type DBInserter interface {
 	// Ingest takes an array of TimeSeries and attepts to store it into the database.
 	// Returns the number of metrics ingested and any error encountered before finishing.
-	Ingest([]prompb.TimeSeries, *InsertCtx) (uint64, error)
+	Ingest([]prompb.TimeSeries, *prompb.WriteRequest) (uint64, error)
 }

--- a/pkg/pgmodel/ingestor_test.go
+++ b/pkg/pgmodel/ingestor_test.go
@@ -45,7 +45,7 @@ func (m *mockInserter) Close() {
 
 }
 
-func (m *mockInserter) InsertNewData(rows map[string][]samplesInfo, ctx *InsertCtx) (uint64, error) {
+func (m *mockInserter) InsertNewData(rows map[string][]samplesInfo) (uint64, error) {
 	return m.InsertData(rows)
 }
 
@@ -254,7 +254,7 @@ func TestDBIngestorIngest(t *testing.T) {
 				db:    &inserter,
 			}
 
-			count, err := i.Ingest(c.metrics, NewInsertCtx())
+			count, err := i.Ingest(c.metrics, NewWriteRequest())
 
 			if err != nil {
 				if c.insertSeriesErr != nil && err != c.insertSeriesErr {

--- a/pkg/pgmodel/labels.go
+++ b/pkg/pgmodel/labels.go
@@ -32,14 +32,14 @@ func EmptyLables() Labels {
 func LabelsFromSlice(ls labels.Labels) (Labels, error) {
 	length := len(ls)
 	labels := Labels{
-		names:  make([]string, 0, length),
-		values: make([]string, 0, length),
+		names:  make([]string, length),
+		values: make([]string, length),
 	}
 
 	labels.metricName = ""
-	for _, l := range ls {
-		labels.names = append(labels.names, l.Name)
-		labels.values = append(labels.values, l.Value)
+	for i, l := range ls {
+		labels.names[i] = l.Name
+		labels.values[i] = l.Value
 		if l.Name == MetricNameLabelName {
 			labels.metricName = l.Value
 		}
@@ -105,14 +105,15 @@ func initLabels(l *Labels) error {
 	return nil
 }
 
-func labelProtosToLabels(labelPairs []prompb.Label, ctx *InsertCtx) (Labels, string, error) {
+func labelProtosToLabels(labelPairs []prompb.Label) (*Labels, string, error) {
 	length := len(labelPairs)
-	labels := ctx.NewLabels(length)
+	labels := NewLabels(length)
 
 	labels.metricName = ""
-	for _, l := range labelPairs {
-		labels.names = append(labels.names, l.Name)
-		labels.values = append(labels.values, l.Value)
+
+	for i, l := range labelPairs {
+		labels.names[i] = l.Name
+		labels.values[i] = l.Value
 		if l.Name == MetricNameLabelName {
 			labels.metricName = l.Value
 		}
@@ -120,10 +121,10 @@ func labelProtosToLabels(labelPairs []prompb.Label, ctx *InsertCtx) (Labels, str
 
 	err := initLabels(labels)
 
-	return *labels, labels.metricName, err
+	return labels, labels.metricName, err
 }
 
-func (l Labels) isEmpty() bool {
+func (l *Labels) isEmpty() bool {
 	return l.names == nil
 }
 
@@ -131,13 +132,26 @@ func (l *Labels) String() string {
 	return l.str
 }
 
+func (l *Labels) reset() {
+	l.metricName = ""
+	for i := range l.names {
+		l.names[i] = ""
+	}
+	l.names = l.names[:0]
+	for i := range l.values {
+		l.values[i] = ""
+	}
+	l.values = l.values[:0]
+	l.str = ""
+}
+
 // Compare returns a comparison int between two Labels
-func (l Labels) Compare(b Labels) int {
+func (l *Labels) Compare(b *Labels) int {
 	return strings.Compare(l.str, b.str)
 }
 
 // Equal returns true if two Labels are equal
-func (l Labels) Equal(b Labels) bool {
+func (l *Labels) Equal(b *Labels) bool {
 	return l.str == b.str
 }
 

--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/allegro/bigcache"
@@ -157,15 +158,20 @@ func (t *SampleInfoIterator) Err() error {
 	return nil
 }
 
+type Cfg struct {
+	AsyncAcks      bool
+	ReportInterval int
+}
+
 // NewPgxIngestorWithMetricCache returns a new Ingestor that uses connection pool and a metrics cache
 // for caching metric table names.
-func NewPgxIngestorWithMetricCache(c *pgxpool.Pool, cache MetricCache) (*DBIngestor, error) {
+func NewPgxIngestorWithMetricCache(c *pgxpool.Pool, cache MetricCache, cfg *Cfg) (*DBIngestor, error) {
 
 	conn := &pgxConnImpl{
 		conn: c,
 	}
 
-	pi, err := newPgxInserter(conn, cache)
+	pi, err := newPgxInserter(conn, cache, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -186,16 +192,29 @@ func NewPgxIngestorWithMetricCache(c *pgxpool.Pool, cache MetricCache) (*DBInges
 func NewPgxIngestor(c *pgxpool.Pool) (*DBIngestor, error) {
 	metrics, _ := bigcache.NewBigCache(DefaultCacheConfig())
 	cache := &MetricNameCache{metrics}
-	return NewPgxIngestorWithMetricCache(c, cache)
+	return NewPgxIngestorWithMetricCache(c, cache, &Cfg{})
 }
 
-func newPgxInserter(conn pgxConn, cache MetricCache) (*pgxInserter, error) {
+func newPgxInserter(conn pgxConn, cache MetricCache, cfg *Cfg) (*pgxInserter, error) {
 	cmc := make(chan struct{}, 1)
 
 	inserter := &pgxInserter{
 		conn:                   conn,
 		metricTableNames:       cache,
 		completeMetricCreation: cmc,
+		asyncAcks:              cfg.AsyncAcks,
+	}
+	if cfg.AsyncAcks && cfg.ReportInterval > 0 {
+		inserter.insertedDatapoints = new(int64)
+		reportInterval := int64(cfg.ReportInterval)
+		go func() {
+			log.Info("msg", fmt.Sprintf("outputting throughpput info once every %ds", reportInterval))
+			tick := time.Tick(time.Duration(reportInterval) * time.Second)
+			for range tick {
+				inserted := atomic.SwapInt64(inserter.insertedDatapoints, 0)
+				log.Info("msg", "Samples write throughput", "samples/sec", inserted/reportInterval)
+			}
+		}()
 	}
 	//on startup run a completeMetricCreation to recover any potentially
 	//incomplete metric
@@ -214,6 +233,8 @@ type pgxInserter struct {
 	metricTableNames       MetricCache
 	inserters              sync.Map
 	completeMetricCreation chan struct{}
+	asyncAcks              bool
+	insertedDatapoints     *int64
 }
 
 func (p *pgxInserter) CompleteMetricCreation() error {
@@ -241,8 +262,8 @@ func (p *pgxInserter) Close() {
 	})
 }
 
-func (p *pgxInserter) InsertNewData(rows map[string][]samplesInfo, ctx *InsertCtx) (uint64, error) {
-	return p.InsertData(rows, ctx)
+func (p *pgxInserter) InsertNewData(rows map[string][]samplesInfo) (uint64, error) {
+	return p.InsertData(rows)
 }
 
 type insertDataRequest struct {
@@ -257,10 +278,9 @@ type insertDataTask struct {
 	errChan  chan error
 }
 
-func (p *pgxInserter) InsertData(rows map[string][]samplesInfo, ctx *InsertCtx) (uint64, error) {
+func (p *pgxInserter) InsertData(rows map[string][]samplesInfo) (uint64, error) {
 	var numRows uint64
 	workFinished := &sync.WaitGroup{}
-	sync := true
 	workFinished.Add(len(rows))
 	errChan := make(chan error, 1)
 	for metricName, data := range rows {
@@ -271,9 +291,8 @@ func (p *pgxInserter) InsertData(rows map[string][]samplesInfo, ctx *InsertCtx) 
 	}
 
 	var err error
-	if sync {
+	if !p.asyncAcks {
 		workFinished.Wait()
-		ctx.Close()
 		select {
 		case err = <-errChan:
 		default:
@@ -282,8 +301,16 @@ func (p *pgxInserter) InsertData(rows map[string][]samplesInfo, ctx *InsertCtx) 
 	} else {
 		go func() {
 			workFinished.Wait()
-			ctx.Close()
+			select {
+			case err = <-errChan:
+			default:
+			}
 			close(errChan)
+			if err != nil {
+				log.Error("msg", "error on send", "error", err)
+			} else if p.insertedDatapoints != nil {
+				atomic.AddInt64(p.insertedDatapoints, int64(numRows))
+			}
 		}()
 	}
 
@@ -501,12 +528,30 @@ func (h *insertHandler) nonblockingHandleReq() bool {
 }
 
 func (h *insertHandler) handleReq(req insertDataRequest) bool {
+	h.fillKnowSeriesIds(req.data)
 	needsFlush := h.pending.addReq(req)
 	if needsFlush {
 		h.flushPending(h.pending)
 		return true
 	}
 	return false
+}
+
+func (h *insertHandler) fillKnowSeriesIds(sampleInfos []samplesInfo) (numMissingSeries int) {
+	for i, series := range sampleInfos {
+		if series.seriesID > 0 {
+			continue
+		}
+		id, ok := h.seriesCache[series.labels.String()]
+		if ok {
+			sampleInfos[i].seriesID = id
+			FinishLabels(series.labels)
+			series.labels = nil
+		} else {
+			numMissingSeries++
+		}
+	}
+	return
 }
 
 func (h *insertHandler) flush() {
@@ -552,16 +597,7 @@ func (h *insertHandler) flushPending(pending *pendingBuffer) {
 }
 
 func (h *insertHandler) setSeriesIds(sampleInfos []samplesInfo) (string, error) {
-	numMissingSeries := 0
-
-	for i, series := range sampleInfos {
-		id, ok := h.seriesCache[series.labels.String()]
-		if ok {
-			sampleInfos[i].seriesID = id
-		} else {
-			numMissingSeries++
-		}
-	}
+	numMissingSeries := h.fillKnowSeriesIds(sampleInfos)
 
 	if numMissingSeries == 0 {
 		return "", nil
@@ -573,7 +609,7 @@ func (h *insertHandler) setSeriesIds(sampleInfos []samplesInfo) (string, error) 
 			seriesToInsert = append(seriesToInsert, &sampleInfos[i])
 		}
 	}
-	var lastSeenLabel Labels
+	var lastSeenLabel *Labels
 
 	batch := h.conn.NewBatch()
 	numSQLFunctionCalls := 0
@@ -586,7 +622,7 @@ func (h *insertHandler) setSeriesIds(sampleInfos []samplesInfo) (string, error) 
 	batchSeries := make([][]*samplesInfo, 0, len(seriesToInsert))
 	// group the seriesToInsert by labels, one slice array per unique labels
 	for _, curr := range seriesToInsert {
-		if !lastSeenLabel.isEmpty() && lastSeenLabel.Equal(curr.labels) {
+		if lastSeenLabel != nil && lastSeenLabel.Equal(curr.labels) {
 			batchSeries[len(batchSeries)-1] = append(batchSeries[len(batchSeries)-1], curr)
 			continue
 		}

--- a/pkg/pgmodel/pgx_test.go
+++ b/pkg/pgmodel/pgx_test.go
@@ -541,12 +541,12 @@ func TestPGXInserterInsertData(t *testing.T) {
 				getMetricErr: c.metricsGetErr,
 				setMetricErr: c.metricsSetErr,
 			}
-			inserter, err := newPgxInserter(mock, mockMetrics)
+			inserter, err := newPgxInserter(mock, mockMetrics, false)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, err = inserter.InsertData(c.rows, NewInsertCtx())
+			_, err = inserter.InsertData(c.rows)
 
 			if err != nil {
 				var expErr error

--- a/pkg/prompb/remote.pb.go
+++ b/pkg/prompb/remote.pb.go
@@ -881,38 +881,10 @@ func sozRemote(x uint64) (n int) {
 }
 func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowRemote
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: WriteRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: WriteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
-			}
-			var msglen int
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowRemote
@@ -922,21 +894,49 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= int(b&0x7F) << shift
+				wire |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
-				return ErrInvalidLengthRemote
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return fmt.Errorf("proto: WriteRequest: wiretype end group for non-group")
 			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthRemote
+			if fieldNum <= 0 {
+				return fmt.Errorf("proto: WriteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowRemote
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return ErrInvalidLengthRemote
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return ErrInvalidLengthRemote
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
 			if len(m.Timeseries) < cap(m.Timeseries) {
 				m.Timeseries = m.Timeseries[:len(m.Timeseries)+1]
 				m.Timeseries[len(m.Timeseries)-1].Reset()
@@ -946,22 +946,22 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipRemote(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthRemote
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthRemote
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := skipRemote(dAtA[iNdEx:])
+				if err != nil {
+					return err
+				}
+				if skippy < 0 {
+					return ErrInvalidLengthRemote
+				}
+				if (iNdEx + skippy) < 0 {
+					return ErrInvalidLengthRemote
+				}
+				if (iNdEx + skippy) > l {
+					return io.ErrUnexpectedEOF
+				}
 			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}

--- a/pkg/prompb/types.pb.go
+++ b/pkg/prompb/types.pb.go
@@ -87,7 +87,7 @@ type Sample struct {
 	Timestamp            int64    `protobuf:"varint,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	XXX_sizecache int32 `json:"-"`
 }
 
 func (m *Sample) Reset()         { *m = Sample{} }
@@ -146,7 +146,7 @@ type TimeSeries struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *TimeSeries) Reset()         { *m = TimeSeries{Labels : m.Labels[:0], Samples: m.Samples[:0]} }
+func (m *TimeSeries) Reset()         { *m = TimeSeries{Labels: m.Labels[:0], Samples: m.Samples[:0]} }
 func (m *TimeSeries) String() string { return proto.CompactTextString(m) }
 func (*TimeSeries) ProtoMessage()    {}
 func (*TimeSeries) Descriptor() ([]byte, []int) {
@@ -1328,38 +1328,10 @@ func (m *Sample) Unmarshal(dAtA []byte) error {
 }
 func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowTypes
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: TimeSeries: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: TimeSeries: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
-			}
-			var msglen int
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowTypes
@@ -1369,21 +1341,49 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= int(b&0x7F) << shift
+				wire |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
-				return ErrInvalidLengthTypes
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return fmt.Errorf("proto: TimeSeries: wiretype end group for non-group")
 			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthTypes
+			if fieldNum <= 0 {
+				return fmt.Errorf("proto: TimeSeries: illegal tag %d (wire type %d)", fieldNum, wire)
 			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
 			if len(m.Labels) < cap(m.Labels) {
 				m.Labels = m.Labels[:len(m.Labels)+1]
 				m.Labels[len(m.Labels)-1].Reset()
@@ -1393,36 +1393,36 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 			if err := m.Labels[len(m.Labels)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Samples", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return fmt.Errorf("proto: wrong wireType = %d for field Samples", wireType)
 				}
-				if iNdEx >= l {
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
 			if len(m.Samples) < cap(m.Samples) {
 				m.Samples = m.Samples[:len(m.Samples)+1]
 				m.Samples[len(m.Samples)-1].Reset()
@@ -1432,22 +1432,22 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 			if err := m.Samples[len(m.Samples)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipTypes(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := skipTypes(dAtA[iNdEx:])
+				if err != nil {
+					return err
+				}
+				if skippy < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if (iNdEx + skippy) < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if (iNdEx + skippy) > l {
+					return io.ErrUnexpectedEOF
+				}
 			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
@@ -1578,38 +1578,10 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 }
 func (m *Labels) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowTypes
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Labels: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Labels: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
-			}
-			var msglen int
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowTypes
@@ -1619,21 +1591,49 @@ func (m *Labels) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= int(b&0x7F) << shift
+				wire |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
-				return ErrInvalidLengthTypes
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return fmt.Errorf("proto: Labels: wiretype end group for non-group")
 			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthTypes
+			if fieldNum <= 0 {
+				return fmt.Errorf("proto: Labels: illegal tag %d (wire type %d)", fieldNum, wire)
 			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
 			if len(m.Labels) < cap(m.Labels) {
 				m.Labels = m.Labels[:len(m.Labels)+1]
 				m.Labels[len(m.Labels)-1].Reset()
@@ -1643,22 +1643,22 @@ func (m *Labels) Unmarshal(dAtA []byte) error {
 			if err := m.Labels[len(m.Labels)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipTypes(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := skipTypes(dAtA[iNdEx:])
+				if err != nil {
+					return err
+				}
+				if skippy < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if (iNdEx + skippy) < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if (iNdEx + skippy) > l {
+					return io.ErrUnexpectedEOF
+				}
 			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}


### PR DESCRIPTION
This commit reduces memory usage by ensuring WriteRequests and Labels
are freed as soon as they are no longer needed. For WriteRequests, this
is immediately after parseData is called, as at that point we are only
going to used the parsed version. For Labels this is as soon as we have
the SeriesId for the Labels.

This commit also adds a command line flag for async-acks, and the
ability ro report the actual throughput of said acks.