### PR TITLE
Add option to output postgres log, and clean docker image when done

### DIFF
--- a/pkg/internal/testhelpers/containers_test.go
+++ b/pkg/internal/testhelpers/containers_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	ctx := context.Background()
 	if !testing.Short() && *useDocker {
-		pgContainer, err := StartPGContainer(ctx, true, "")
+		pgContainer, err := StartPGContainer(ctx, true, "", false)
 		if err != nil {
 			fmt.Println("Error setting up container", err)
 			os.Exit(1)

--- a/pkg/util/election_test.go
+++ b/pkg/util/election_test.go
@@ -211,7 +211,7 @@ func TestMain(m *testing.M) {
 	}
 	ctx := context.Background()
 	if !testing.Short() && *useDocker {
-		container, err := testhelpers.StartPGContainer(ctx, false, "")
+		container, err := testhelpers.StartPGContainer(ctx, false, "", false)
 		if err != nil {
 			fmt.Println("Error setting up container", err)
 			os.Exit(1)


### PR DESCRIPTION
Just like it says in the title. Add
```
-print-logs true
```
to print the postgres logs in the `end_to_end` tests