### PR TITLE
Switch to dedicated CopyFrom workers

### DIFF
--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -63,7 +63,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	if maxProcs <= 0 {
 		maxProcs = 1
 	}
-	connectionPool, err := pgxpool.Connect(context.Background(), connectionStr+fmt.Sprintf(" pool_max_conns=%d pool_min_conns=%d", 5*maxProcs, maxProcs))
+	connectionPool, err := pgxpool.Connect(context.Background(), connectionStr+fmt.Sprintf(" pool_max_conns=%d pool_min_conns=%d", maxProcs*pgmodel.ConnectionsPerProc, maxProcs))
 
 	log.Info("msg", util.MaskPassword(connectionStr))
 


### PR DESCRIPTION
This commit switches the way we do inserts into the database. Instead
of each InsertHandler running CopyFrom directly when it finishes a
batch of data, it instead forwards the values to a pool of CopyFrom
workers, who perform the actual insertion. This is intended to provide
a few advantages:
  1. If one metric is very hot, it will be able to continue
     processing new data at the same time as earlier values are
     inserted. Before this commit, individual metrics would experience
     head-of-line blocking in such cases.
  2. This may allow a single worker to handle all inserts in the event
     that the insert-rate is low enough.
  3. This should ease experimentation with batching across metrics.