### PR TITLE
Add promql endpoint pushdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/allegro/bigcache v1.2.1
 	github.com/docker/go-connections v0.4.0
+	github.com/edsrzf/mmap-go v1.0.0
 	github.com/go-kit/kit v0.10.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang-migrate/migrate/v4 v4.9.1
@@ -18,6 +19,7 @@ require (
 	github.com/jackc/pgtype v1.2.0
 	github.com/jackc/pgx/v4 v4.4.1
 	github.com/jamiealquiza/envy v1.1.0
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
@@ -27,6 +29,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.5.1
 	google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb
 	google.golang.org/grpc v1.29.0
+	github.com/uber/jaeger-client-go v2.23.0+incompatible
 )
 
 replace github.com/jackc/pgconn => github.com/JLockerman/pgconn v1.5.3-0.20200513205926-64cd2ce264ca

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -11,9 +11,9 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 

--- a/pkg/api/query_range.go
+++ b/pkg/api/query_range.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 

--- a/pkg/api/query_range_test.go
+++ b/pkg/api/query_range_test.go
@@ -5,15 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/promql"
-	"github.com/timescale/timescale-prometheus/pkg/log"
-	"github.com/timescale/timescale-prometheus/pkg/query"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
+	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 
 func TestRangedQuery(t *testing.T) {

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -5,18 +5,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/storage"
-	"github.com/timescale/timescale-prometheus/pkg/log"
-	"github.com/timescale/timescale-prometheus/pkg/prompb"
-	"github.com/timescale/timescale-prometheus/pkg/query"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/prompb"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
+	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 
 type mockSeriesSet struct{}
@@ -42,10 +44,10 @@ func (m mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
 	panic("implement me")
 }
 
-func (m mockQuerier) Select(int64, int64, bool, *storage.SelectHints, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (m mockQuerier) Select(int64, int64, bool, *storage.SelectHints, []parser.Node, ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
 	time.Sleep(m.timeToSleep)
 
-	return &mockSeriesSet{}, nil, m.err
+	return &mockSeriesSet{}, nil, nil, m.err
 }
 
 func TestParseDuration(t *testing.T) {

--- a/pkg/pgmodel/migrate.go
+++ b/pkg/pgmodel/migrate.go
@@ -27,6 +27,8 @@ const (
 	metadataUpdateNoExtension   = "INSERT INTO _timescaledb_catalog.metadata(key, value, include_in_telemetry) VALUES ($1, $2, $3) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, include_in_telemetry = EXCLUDED.include_in_telemetry"
 )
 
+var ExtensionIsInstalled = false
+
 type mySrc struct {
 	source.Driver
 }
@@ -137,7 +139,10 @@ func Migrate(db *sql.DB, versionInfo VersionInfo) (err error) {
 
 	_, extErr := db.Exec(fmt.Sprintf(extensionInstall, extSchema))
 	if extErr != nil {
+		ExtensionIsInstalled = false
 		log.Warn("msg", "timescale_prometheus_extra extension not installed", "cause", extErr)
+	} else {
+		ExtensionIsInstalled = true
 	}
 
 	// Insert metadata.

--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -863,7 +863,8 @@ func (q *pgxQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *stor
 		return nil, nil, nil, err
 	}
 
-	return buildSeriesSet(rows, topNode, sortSeries)
+	ss, warn, err := buildSeriesSet(rows, sortSeries)
+	return ss, topNode, warn, err
 }
 
 func (q *pgxQuerier) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {
@@ -976,7 +977,6 @@ func (q *pgxQuerier) querySingleMetric(metric string, filter metricTimeRangeFilt
 	if err != nil {
 		return nil, nil, err
 	}
-	//fmt.Println(sqlQuery, values, topNode)
 	rows, err := q.conn.Query(context.Background(), sqlQuery, values...)
 
 	if err != nil {

--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/log"
 	"github.com/timescale/timescale-prometheus/pkg/prompb"
@@ -855,14 +856,14 @@ func (q *pgxQuerier) HealthCheck() error {
 	return nil
 }
 
-func (q *pgxQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *pgxQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
 	rows, err := q.getResultRows(mint, maxt, ms)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return buildSeriesSet(rows, sortSeries)
+	return buildSeriesSet(rows, nil, sortSeries)
 }
 
 func (q *pgxQuerier) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {

--- a/pkg/pgmodel/pgx_test.go
+++ b/pkg/pgmodel/pgx_test.go
@@ -855,7 +855,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				},
 			},
 			sqlQueries: []string{`SELECT table_name FROM _prom_catalog.get_metric_table_name_if_exists($1)`,
-				`SELECT (key_value_array(s.labels)).*, array_agg(m.time ORDER BY time), array_agg(m.value ORDER BY time)
+				`SELECT (key_value_array(s.labels)).*, array_agg(m.time ORDER BY time) as time_array, array_agg(m.value ORDER BY time)
 	FROM "prom_data"."bar" m
 	INNER JOIN "prom_data_series"."bar" s
 	ON m.series_id = s.id

--- a/pkg/pgmodel/querier.go
+++ b/pkg/pgmodel/querier.go
@@ -6,6 +6,7 @@ package pgmodel
 
 import (
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/prompb"
 )
@@ -19,7 +20,7 @@ type Reader interface {
 // matching timeseries.
 type Querier interface {
 	Query(*prompb.Query) ([]*prompb.TimeSeries, error)
-	Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error)
+	Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error)
 }
 
 //HealthChecker allows checking for proper operations.

--- a/pkg/pgmodel/querier_test.go
+++ b/pkg/pgmodel/querier_test.go
@@ -5,11 +5,12 @@ package pgmodel
 
 import (
 	"fmt"
-	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/storage"
 	"reflect"
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/prompb"
 )
 
@@ -19,8 +20,8 @@ type mockQuerier struct {
 	healthCheckCalled bool
 }
 
-func (q *mockQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return nil, nil, nil
+func (q *mockQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
+	return nil, nil, nil, nil
 }
 
 func (q *mockQuerier) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {

--- a/pkg/pgmodel/query_builder.go
+++ b/pkg/pgmodel/query_builder.go
@@ -296,7 +296,7 @@ func (t *queryFinalizer) Finalize() (string, []interface{}, error) {
 
 /* The path is the list if ancestors (direct parent last) returned node is the last node processed by the pushdown */
 func getQueryFinalizer(otherClauses string, values []interface{}, hints *storage.SelectHints, path []parser.Node) (*queryFinalizer, parser.Node, error) {
-	if path != nil && hints != nil && len(path) >= 2 && !partOfSubquery(path) {
+	if ExtensionIsInstalled && path != nil && hints != nil && len(path) >= 2 && !partOfSubquery(path) {
 		var topNode parser.Node
 
 		node := path[len(path)-2]

--- a/pkg/pgmodel/query_builder.go
+++ b/pkg/pgmodel/query_builder.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/prompb"
 )
@@ -153,10 +154,10 @@ func (c *clauseBuilder) build() ([]string, []interface{}) {
 	return c.clauses, c.args
 }
 
-func buildSeriesSet(rows []pgx.Rows, sortSeries bool) (storage.SeriesSet, storage.Warnings, error) {
+func buildSeriesSet(rows []pgx.Rows, topNode parser.Node, sortSeries bool) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
 	return &pgxSeriesSet{
 		rows: rows,
-	}, nil, nil
+	}, topNode, nil, nil
 }
 
 func buildTimeSeries(rows pgx.Rows) ([]*prompb.TimeSeries, error) {

--- a/pkg/pgmodel/series_set.go
+++ b/pkg/pgmodel/series_set.go
@@ -57,7 +57,6 @@ func (p *pgxSeriesSet) At() storage.Series {
 
 	ps := &pgxSeries{}
 	if err := p.rows[p.rowIdx].Scan(&ps.labelNames, &ps.labelValues, &ps.times, &ps.values); err != nil {
-		println(err.Error())
 		return nil
 	}
 

--- a/pkg/promql/bench_test.go
+++ b/pkg/promql/bench_test.go
@@ -1,0 +1,266 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+func BenchmarkRangeQuery(b *testing.B) {
+	storage := teststorage.New(b)
+	defer storage.Close()
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 50000000,
+		Timeout:    100 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	metrics := []labels.Labels{}
+	metrics = append(metrics, labels.FromStrings("__name__", "a_one"))
+	metrics = append(metrics, labels.FromStrings("__name__", "b_one"))
+	for j := 0; j < 10; j++ {
+		metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", strconv.Itoa(j)))
+	}
+	metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", "+Inf"))
+
+	for i := 0; i < 10; i++ {
+		metrics = append(metrics, labels.FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)))
+		metrics = append(metrics, labels.FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
+		for j := 0; j < 10; j++ {
+			metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
+		}
+		metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", "+Inf"))
+	}
+
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, labels.FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)))
+		metrics = append(metrics, labels.FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
+		for j := 0; j < 10; j++ {
+			metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
+		}
+		metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", "+Inf"))
+	}
+	refs := make([]uint64, len(metrics))
+
+	// A day of data plus 10k steps.
+	numIntervals := 8640 + 10000
+
+	for s := 0; s < numIntervals; s++ {
+		a := storage.Appender()
+		ts := int64(s * 10000) // 10s interval.
+		for i, metric := range metrics {
+			err := a.AddFast(refs[i], ts, float64(s))
+			if err != nil {
+				refs[i], _ = a.Add(metric, ts, float64(s))
+			}
+		}
+		if err := a.Commit(); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	type benchCase struct {
+		expr  string
+		steps int
+	}
+	cases := []benchCase{
+		// Plain retrieval.
+		{
+			expr: "a_X",
+		},
+		// Simple rate.
+		{
+			expr: "rate(a_X[1m])",
+		},
+		{
+			expr:  "rate(a_X[1m])",
+			steps: 10000,
+		},
+		// Holt-Winters and long ranges.
+		{
+			expr: "holt_winters(a_X[1d], 0.3, 0.3)",
+		},
+		{
+			expr: "changes(a_X[1d])",
+		},
+		{
+			expr: "rate(a_X[1d])",
+		},
+		{
+			expr: "absent_over_time(a_X[1d])",
+		},
+		// Unary operators.
+		{
+			expr: "-a_X",
+		},
+		// Binary operators.
+		{
+			expr: "a_X - b_X",
+		},
+		{
+			expr:  "a_X - b_X",
+			steps: 10000,
+		},
+		{
+			expr: "a_X and b_X{l=~'.*[0-4]$'}",
+		},
+		{
+			expr: "a_X or b_X{l=~'.*[0-4]$'}",
+		},
+		{
+			expr: "a_X unless b_X{l=~'.*[0-4]$'}",
+		},
+		// Simple functions.
+		{
+			expr: "abs(a_X)",
+		},
+		{
+			expr: "label_replace(a_X, 'l2', '$1', 'l', '(.*)')",
+		},
+		{
+			expr: "label_join(a_X, 'l2', '-', 'l', 'l')",
+		},
+		// Simple aggregations.
+		{
+			expr: "sum(a_X)",
+		},
+		{
+			expr: "sum without (l)(h_X)",
+		},
+		{
+			expr: "sum without (le)(h_X)",
+		},
+		{
+			expr: "sum by (l)(h_X)",
+		},
+		{
+			expr: "sum by (le)(h_X)",
+		},
+		// Combinations.
+		{
+			expr: "rate(a_X[1m]) + rate(b_X[1m])",
+		},
+		{
+			expr: "sum without (l)(rate(a_X[1m]))",
+		},
+		{
+			expr: "sum without (l)(rate(a_X[1m])) / sum without (l)(rate(b_X[1m]))",
+		},
+		{
+			expr: "histogram_quantile(0.9, rate(h_X[5m]))",
+		},
+	}
+
+	// X in an expr will be replaced by different metric sizes.
+	tmp := []benchCase{}
+	for _, c := range cases {
+		if !strings.Contains(c.expr, "X") {
+			tmp = append(tmp, c)
+		} else {
+			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "one", -1), steps: c.steps})
+			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "ten", -1), steps: c.steps})
+			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "hundred", -1), steps: c.steps})
+		}
+	}
+	cases = tmp
+
+	// No step will be replaced by cases with the standard step.
+	tmp = []benchCase{}
+	for _, c := range cases {
+		if c.steps != 0 {
+			tmp = append(tmp, c)
+		} else {
+			tmp = append(tmp, benchCase{expr: c.expr, steps: 1})
+			tmp = append(tmp, benchCase{expr: c.expr, steps: 10})
+			tmp = append(tmp, benchCase{expr: c.expr, steps: 100})
+			tmp = append(tmp, benchCase{expr: c.expr, steps: 1000})
+		}
+	}
+	cases = tmp
+	for _, c := range cases {
+		name := fmt.Sprintf("expr=%s,steps=%d", c.expr, c.steps)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				qry, err := engine.NewRangeQuery(
+					storage, c.expr,
+					time.Unix(int64((numIntervals-c.steps)*10), 0),
+					time.Unix(int64(numIntervals*10), 0), time.Second*10)
+				if err != nil {
+					b.Fatal(err)
+				}
+				res := qry.Exec(context.Background())
+				if res.Err != nil {
+					b.Fatal(res.Err)
+				}
+				qry.Close()
+			}
+		})
+	}
+}
+
+func BenchmarkParser(b *testing.B) {
+	cases := []string{
+		"a",
+		"metric",
+		"1",
+		"1 >= bool 1",
+		"1 + 2/(3*1)",
+		"foo or bar",
+		"foo and bar unless baz or qux",
+		"bar + on(foo) bla / on(baz, buz) group_right(test) blub",
+		"foo / ignoring(test,blub) group_left(blub) bar",
+		"foo - ignoring(test,blub) group_right(bar,foo) bar",
+		`foo{a="b", foo!="bar", test=~"test", bar!~"baz"}`,
+		`min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]`,
+		"sum without(and, by, avg, count, alert, annotations)(some_metric) [30m:10s]",
+	}
+	errCases := []string{
+		"(",
+		"}",
+		"1 or 1",
+		"1 or on(bar) foo",
+		"foo unless on(bar) group_left(baz) bar",
+		"test[5d] OFFSET 10s [10m:5s]",
+	}
+
+	for _, c := range cases {
+		b.Run(c, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				parser.ParseExpr(c)
+			}
+		})
+	}
+	for _, c := range errCases {
+		name := fmt.Sprintf("%s (should fail)", c)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				parser.ParseExpr(c)
+			}
+		})
+	}
+}

--- a/pkg/promql/bench_test.go
+++ b/pkg/promql/bench_test.go
@@ -23,11 +23,10 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/util/teststorage"
 )
 
 func BenchmarkRangeQuery(b *testing.B) {
-	storage := teststorage.New(b)
+	storage := NewTestStorage(b)
 	defer storage.Close()
 	opts := EngineOpts{
 		Logger:     nil,

--- a/pkg/promql/engine.go
+++ b/pkg/promql/engine.go
@@ -1,0 +1,2119 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/uber/jaeger-client-go"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/stats"
+)
+
+const (
+	namespace            = "prometheus"
+	subsystem            = "engine"
+	queryTag             = "query"
+	env                  = "query execution"
+	defaultLookbackDelta = 5 * time.Minute
+
+	// The largest SampleValue that can be converted to an int64 without overflow.
+	maxInt64 = 9223372036854774784
+	// The smallest SampleValue that can be converted to an int64 without underflow.
+	minInt64 = -9223372036854775808
+)
+
+var (
+	// DefaultEvaluationInterval is the default evaluation interval of
+	// a subquery in milliseconds.
+	DefaultEvaluationInterval int64
+)
+
+// SetDefaultEvaluationInterval sets DefaultEvaluationInterval.
+func SetDefaultEvaluationInterval(ev time.Duration) {
+	atomic.StoreInt64(&DefaultEvaluationInterval, durationToInt64Millis(ev))
+}
+
+// GetDefaultEvaluationInterval returns the DefaultEvaluationInterval as time.Duration.
+func GetDefaultEvaluationInterval() int64 {
+	return atomic.LoadInt64(&DefaultEvaluationInterval)
+}
+
+type engineMetrics struct {
+	currentQueries       prometheus.Gauge
+	maxConcurrentQueries prometheus.Gauge
+	queryLogEnabled      prometheus.Gauge
+	queryLogFailures     prometheus.Counter
+	queryQueueTime       prometheus.Summary
+	queryPrepareTime     prometheus.Summary
+	queryInnerEval       prometheus.Summary
+	queryResultSort      prometheus.Summary
+}
+
+// convertibleToInt64 returns true if v does not over-/underflow an int64.
+func convertibleToInt64(v float64) bool {
+	return v <= maxInt64 && v >= minInt64
+}
+
+type (
+	// ErrQueryTimeout is returned if a query timed out during processing.
+	ErrQueryTimeout string
+	// ErrQueryCanceled is returned if a query was canceled during processing.
+	ErrQueryCanceled string
+	// ErrTooManySamples is returned if a query would load more than the maximum allowed samples into memory.
+	ErrTooManySamples string
+	// ErrStorage is returned if an error was encountered in the storage layer
+	// during query handling.
+	ErrStorage struct{ Err error }
+)
+
+func (e ErrQueryTimeout) Error() string {
+	return fmt.Sprintf("query timed out in %s", string(e))
+}
+func (e ErrQueryCanceled) Error() string {
+	return fmt.Sprintf("query was canceled in %s", string(e))
+}
+func (e ErrTooManySamples) Error() string {
+	return fmt.Sprintf("query processing would load too many samples into memory in %s", string(e))
+}
+func (e ErrStorage) Error() string {
+	return e.Err.Error()
+}
+
+// QueryLogger is an interface that can be used to log all the queries logged
+// by the engine.
+type QueryLogger interface {
+	Log(...interface{}) error
+	Close() error
+}
+
+// A Query is derived from an a raw query string and can be run against an engine
+// it is associated with.
+type Query interface {
+	// Exec processes the query. Can only be called once.
+	Exec(ctx context.Context) *Result
+	// Close recovers memory used by the query result.
+	Close()
+	// Statement returns the parsed statement of the query.
+	Statement() parser.Statement
+	// Stats returns statistics about the lifetime of the query.
+	Stats() *stats.QueryTimers
+	// Cancel signals that a running query execution should be aborted.
+	Cancel()
+}
+
+// query implements the Query interface.
+type query struct {
+	// Underlying data provider.
+	queryable storage.Queryable
+	// The original query string.
+	q string
+	// Statement of the parsed query.
+	stmt parser.Statement
+	// Timer stats for the query execution.
+	stats *stats.QueryTimers
+	// Result matrix for reuse.
+	matrix Matrix
+	// Cancellation function for the query.
+	cancel func()
+
+	// The engine against which the query is executed.
+	ng *Engine
+}
+
+type queryOrigin struct{}
+
+// Statement implements the Query interface.
+func (q *query) Statement() parser.Statement {
+	return q.stmt
+}
+
+// Stats implements the Query interface.
+func (q *query) Stats() *stats.QueryTimers {
+	return q.stats
+}
+
+// Cancel implements the Query interface.
+func (q *query) Cancel() {
+	if q.cancel != nil {
+		q.cancel()
+	}
+}
+
+// Close implements the Query interface.
+func (q *query) Close() {
+	for _, s := range q.matrix {
+		putPointSlice(s.Points)
+	}
+}
+
+// Exec implements the Query interface.
+func (q *query) Exec(ctx context.Context) *Result {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span.SetTag(queryTag, q.stmt.String())
+	}
+
+	// Exec query.
+	res, warnings, err := q.ng.exec(ctx, q)
+
+	return &Result{Err: err, Value: res, Warnings: warnings}
+}
+
+// contextDone returns an error if the context was canceled or timed out.
+func contextDone(ctx context.Context, env string) error {
+	if err := ctx.Err(); err != nil {
+		return contextErr(err, env)
+	}
+	return nil
+}
+
+func contextErr(err error, env string) error {
+	switch err {
+	case context.Canceled:
+		return ErrQueryCanceled(env)
+	case context.DeadlineExceeded:
+		return ErrQueryTimeout(env)
+	default:
+		return err
+	}
+}
+
+// EngineOpts contains configuration options used when creating a new Engine.
+type EngineOpts struct {
+	Logger             log.Logger
+	Reg                prometheus.Registerer
+	MaxSamples         int
+	Timeout            time.Duration
+	ActiveQueryTracker *ActiveQueryTracker
+	// LookbackDelta determines the time since the last sample after which a time
+	// series is considered stale.
+	LookbackDelta time.Duration
+}
+
+// Engine handles the lifetime of queries from beginning to end.
+// It is connected to a querier.
+type Engine struct {
+	logger             log.Logger
+	metrics            *engineMetrics
+	timeout            time.Duration
+	maxSamplesPerQuery int
+	activeQueryTracker *ActiveQueryTracker
+	queryLogger        QueryLogger
+	queryLoggerLock    sync.RWMutex
+	lookbackDelta      time.Duration
+}
+
+// NewEngine returns a new engine.
+func NewEngine(opts EngineOpts) *Engine {
+	if opts.Logger == nil {
+		opts.Logger = log.NewNopLogger()
+	}
+
+	metrics := &engineMetrics{
+		currentQueries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queries",
+			Help:      "The current number of queries being executed or waiting.",
+		}),
+		queryLogEnabled: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "query_log_enabled",
+			Help:      "State of the query log.",
+		}),
+		queryLogFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "query_log_failures_total",
+			Help:      "The number of query log failures.",
+		}),
+		maxConcurrentQueries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queries_concurrent_max",
+			Help:      "The max number of concurrent queries.",
+		}),
+		queryQueueTime: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "queue_time"},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+		queryPrepareTime: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "prepare_time"},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+		queryInnerEval: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "inner_eval"},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+		queryResultSort: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "result_sort"},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+	}
+
+	if t := opts.ActiveQueryTracker; t != nil {
+		metrics.maxConcurrentQueries.Set(float64(t.GetMaxConcurrent()))
+	} else {
+		metrics.maxConcurrentQueries.Set(-1)
+	}
+
+	if opts.LookbackDelta == 0 {
+		opts.LookbackDelta = defaultLookbackDelta
+		if l := opts.Logger; l != nil {
+			level.Debug(l).Log("msg", "Lookback delta is zero, setting to default value", "value", defaultLookbackDelta)
+		}
+	}
+
+	if opts.Reg != nil {
+		opts.Reg.MustRegister(
+			metrics.currentQueries,
+			metrics.maxConcurrentQueries,
+			metrics.queryLogEnabled,
+			metrics.queryLogFailures,
+			metrics.queryQueueTime,
+			metrics.queryPrepareTime,
+			metrics.queryInnerEval,
+			metrics.queryResultSort,
+		)
+	}
+
+	return &Engine{
+		timeout:            opts.Timeout,
+		logger:             opts.Logger,
+		metrics:            metrics,
+		maxSamplesPerQuery: opts.MaxSamples,
+		activeQueryTracker: opts.ActiveQueryTracker,
+		lookbackDelta:      opts.LookbackDelta,
+	}
+}
+
+// SetQueryLogger sets the query logger.
+func (ng *Engine) SetQueryLogger(l QueryLogger) {
+	ng.queryLoggerLock.Lock()
+	defer ng.queryLoggerLock.Unlock()
+
+	if ng.queryLogger != nil {
+		// An error closing the old file descriptor should
+		// not make reload fail; only log a warning.
+		err := ng.queryLogger.Close()
+		if err != nil {
+			level.Warn(ng.logger).Log("msg", "Error while closing the previous query log file", "err", err)
+		}
+	}
+
+	ng.queryLogger = l
+
+	if l != nil {
+		ng.metrics.queryLogEnabled.Set(1)
+	} else {
+		ng.metrics.queryLogEnabled.Set(0)
+	}
+}
+
+// NewInstantQuery returns an evaluation query for the given expression at the given time.
+func (ng *Engine) NewInstantQuery(q storage.Queryable, qs string, ts time.Time) (Query, error) {
+	expr, err := parser.ParseExpr(qs)
+	if err != nil {
+		return nil, err
+	}
+	qry := ng.newQuery(q, expr, ts, ts, 0)
+	qry.q = qs
+
+	return qry, nil
+}
+
+// NewRangeQuery returns an evaluation query for the given time range and with
+// the resolution set by the interval.
+func (ng *Engine) NewRangeQuery(q storage.Queryable, qs string, start, end time.Time, interval time.Duration) (Query, error) {
+	expr, err := parser.ParseExpr(qs)
+	if err != nil {
+		return nil, err
+	}
+	if expr.Type() != parser.ValueTypeVector && expr.Type() != parser.ValueTypeScalar {
+		return nil, errors.Errorf("invalid expression type %q for range query, must be Scalar or instant Vector", parser.DocumentedType(expr.Type()))
+	}
+	qry := ng.newQuery(q, expr, start, end, interval)
+	qry.q = qs
+
+	return qry, nil
+}
+
+func (ng *Engine) newQuery(q storage.Queryable, expr parser.Expr, start, end time.Time, interval time.Duration) *query {
+	es := &parser.EvalStmt{
+		Expr:     expr,
+		Start:    start,
+		End:      end,
+		Interval: interval,
+	}
+	qry := &query{
+		stmt:      es,
+		ng:        ng,
+		stats:     stats.NewQueryTimers(),
+		queryable: q,
+	}
+	return qry
+}
+
+func (ng *Engine) newTestQuery(f func(context.Context) error) Query {
+	qry := &query{
+		q:     "test statement",
+		stmt:  parser.TestStmt(f),
+		ng:    ng,
+		stats: stats.NewQueryTimers(),
+	}
+	return qry
+}
+
+// exec executes the query.
+//
+// At this point per query only one EvalStmt is evaluated. Alert and record
+// statements are not handled by the Engine.
+func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, w storage.Warnings, err error) {
+	ng.metrics.currentQueries.Inc()
+	defer ng.metrics.currentQueries.Dec()
+
+	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
+	q.cancel = cancel
+
+	defer func() {
+		ng.queryLoggerLock.RLock()
+		if l := ng.queryLogger; l != nil {
+			params := make(map[string]interface{}, 4)
+			params["query"] = q.q
+			if eq, ok := q.Statement().(*parser.EvalStmt); ok {
+				params["start"] = formatDate(eq.Start)
+				params["end"] = formatDate(eq.End)
+				// The step provided by the user is in seconds.
+				params["step"] = int64(eq.Interval / (time.Second / time.Nanosecond))
+			}
+			f := []interface{}{"params", params}
+			if err != nil {
+				f = append(f, "error", err)
+			}
+			f = append(f, "stats", stats.NewQueryStats(q.Stats()))
+			if span := opentracing.SpanFromContext(ctx); span != nil {
+				if spanCtx, ok := span.Context().(jaeger.SpanContext); ok {
+					f = append(f, "spanID", spanCtx.SpanID())
+				}
+			}
+			if origin := ctx.Value(queryOrigin{}); origin != nil {
+				for k, v := range origin.(map[string]interface{}) {
+					f = append(f, k, v)
+				}
+			}
+			if err := l.Log(f...); err != nil {
+				ng.metrics.queryLogFailures.Inc()
+				level.Error(ng.logger).Log("msg", "can't log query", "err", err)
+			}
+		}
+		ng.queryLoggerLock.RUnlock()
+	}()
+
+	execSpanTimer, ctx := q.stats.GetSpanTimer(ctx, stats.ExecTotalTime)
+	defer execSpanTimer.Finish()
+
+	queueSpanTimer, _ := q.stats.GetSpanTimer(ctx, stats.ExecQueueTime, ng.metrics.queryQueueTime)
+	// Log query in active log. The active log guarantees that we don't run over
+	// MaxConcurrent queries.
+	if ng.activeQueryTracker != nil {
+		queryIndex, err := ng.activeQueryTracker.Insert(ctx, q.q)
+		if err != nil {
+			queueSpanTimer.Finish()
+			return nil, nil, contextErr(err, "query queue")
+		}
+		defer ng.activeQueryTracker.Delete(queryIndex)
+	}
+	queueSpanTimer.Finish()
+
+	// Cancel when execution is done or an error was raised.
+	defer q.cancel()
+
+	const env = "query execution"
+
+	evalSpanTimer, ctx := q.stats.GetSpanTimer(ctx, stats.EvalTotalTime)
+	defer evalSpanTimer.Finish()
+
+	// The base context might already be canceled on the first iteration (e.g. during shutdown).
+	if err := contextDone(ctx, env); err != nil {
+		return nil, nil, err
+	}
+
+	switch s := q.Statement().(type) {
+	case *parser.EvalStmt:
+		return ng.execEvalStmt(ctx, q, s)
+	case parser.TestStmt:
+		return nil, nil, s(ctx)
+	}
+
+	panic(errors.Errorf("promql.Engine.exec: unhandled statement of type %T", q.Statement()))
+}
+
+func timeMilliseconds(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond/time.Nanosecond)
+}
+
+func durationMilliseconds(d time.Duration) int64 {
+	return int64(d / (time.Millisecond / time.Nanosecond))
+}
+
+// execEvalStmt evaluates the expression of an evaluation statement for the given time range.
+func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.EvalStmt) (parser.Value, storage.Warnings, error) {
+	prepareSpanTimer, ctxPrepare := query.stats.GetSpanTimer(ctx, stats.QueryPreparationTime, ng.metrics.queryPrepareTime)
+	mint := ng.findMinTime(s)
+	querier, err := query.queryable.Querier(ctxPrepare, timestamp.FromTime(mint), timestamp.FromTime(s.End))
+	if err != nil {
+		prepareSpanTimer.Finish()
+		return nil, nil, err
+	}
+	defer querier.Close()
+
+	warnings, err := ng.populateSeries(ctxPrepare, querier, s)
+	prepareSpanTimer.Finish()
+
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	evalSpanTimer, ctxInnerEval := query.stats.GetSpanTimer(ctx, stats.InnerEvalTime, ng.metrics.queryInnerEval)
+	// Instant evaluation. This is executed as a range evaluation with one step.
+	if s.Start == s.End && s.Interval == 0 {
+		start := timeMilliseconds(s.Start)
+		evaluator := &evaluator{
+			startTimestamp:      start,
+			endTimestamp:        start,
+			interval:            1,
+			ctx:                 ctxInnerEval,
+			maxSamples:          ng.maxSamplesPerQuery,
+			defaultEvalInterval: GetDefaultEvaluationInterval(),
+			logger:              ng.logger,
+			lookbackDelta:       ng.lookbackDelta,
+		}
+
+		val, err := evaluator.Eval(s.Expr)
+		if err != nil {
+			return nil, warnings, err
+		}
+
+		evalSpanTimer.Finish()
+
+		var mat Matrix
+
+		switch result := val.(type) {
+		case Matrix:
+			mat = result
+		case String:
+			return result, warnings, nil
+		default:
+			panic(errors.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+		}
+
+		query.matrix = mat
+		switch s.Expr.Type() {
+		case parser.ValueTypeVector:
+			// Convert matrix with one value per series into vector.
+			vector := make(Vector, len(mat))
+			for i, s := range mat {
+				// Point might have a different timestamp, force it to the evaluation
+				// timestamp as that is when we ran the evaluation.
+				vector[i] = Sample{Metric: s.Metric, Point: Point{V: s.Points[0].V, T: start}}
+			}
+			return vector, warnings, nil
+		case parser.ValueTypeScalar:
+			return Scalar{V: mat[0].Points[0].V, T: start}, warnings, nil
+		case parser.ValueTypeMatrix:
+			return mat, warnings, nil
+		default:
+			panic(errors.Errorf("promql.Engine.exec: unexpected expression type %q", s.Expr.Type()))
+		}
+	}
+
+	// Range evaluation.
+	evaluator := &evaluator{
+		startTimestamp:      timeMilliseconds(s.Start),
+		endTimestamp:        timeMilliseconds(s.End),
+		interval:            durationMilliseconds(s.Interval),
+		ctx:                 ctxInnerEval,
+		maxSamples:          ng.maxSamplesPerQuery,
+		defaultEvalInterval: GetDefaultEvaluationInterval(),
+		logger:              ng.logger,
+		lookbackDelta:       ng.lookbackDelta,
+	}
+	val, err := evaluator.Eval(s.Expr)
+	if err != nil {
+		return nil, warnings, err
+	}
+	evalSpanTimer.Finish()
+
+	mat, ok := val.(Matrix)
+	if !ok {
+		panic(errors.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+	}
+	query.matrix = mat
+
+	if err := contextDone(ctx, "expression evaluation"); err != nil {
+		return nil, warnings, err
+	}
+
+	// TODO(fabxc): where to ensure metric labels are a copy from the storage internals.
+	sortSpanTimer, _ := query.stats.GetSpanTimer(ctx, stats.ResultSortTime, ng.metrics.queryResultSort)
+	sort.Sort(mat)
+	sortSpanTimer.Finish()
+
+	return mat, warnings, nil
+}
+
+// cumulativeSubqueryOffset returns the sum of range and offset of all subqueries in the path.
+func (ng *Engine) cumulativeSubqueryOffset(path []parser.Node) time.Duration {
+	var subqOffset time.Duration
+	for _, node := range path {
+		switch n := node.(type) {
+		case *parser.SubqueryExpr:
+			subqOffset += n.Range + n.Offset
+		}
+	}
+	return subqOffset
+}
+
+func (ng *Engine) findMinTime(s *parser.EvalStmt) time.Time {
+	var maxOffset time.Duration
+	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
+		subqOffset := ng.cumulativeSubqueryOffset(path)
+		switch n := node.(type) {
+		case *parser.VectorSelector:
+			if maxOffset < ng.lookbackDelta+subqOffset {
+				maxOffset = ng.lookbackDelta + subqOffset
+			}
+			if n.Offset+ng.lookbackDelta+subqOffset > maxOffset {
+				maxOffset = n.Offset + ng.lookbackDelta + subqOffset
+			}
+		case *parser.MatrixSelector:
+			if maxOffset < n.Range+subqOffset {
+				maxOffset = n.Range + subqOffset
+			}
+			if m := n.VectorSelector.(*parser.VectorSelector).Offset + n.Range + subqOffset; m > maxOffset {
+				maxOffset = m
+			}
+		}
+		return nil
+	})
+	return s.Start.Add(-maxOffset)
+}
+
+func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s *parser.EvalStmt) (storage.Warnings, error) {
+	var (
+		// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
+		// The evaluation of the VectorSelector inside then evaluates the given range and unsets
+		// the variable.
+		evalRange time.Duration
+		warnings  storage.Warnings
+		err       error
+	)
+
+	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
+		var set storage.SeriesSet
+		var wrn storage.Warnings
+		hints := &storage.SelectHints{
+			Start: timestamp.FromTime(s.Start),
+			End:   timestamp.FromTime(s.End),
+			Step:  durationToInt64Millis(s.Interval),
+		}
+
+		// We need to make sure we select the timerange selected by the subquery.
+		// TODO(gouthamve): cumulativeSubqueryOffset gives the sum of range and the offset
+		// we can optimise it by separating out the range and offsets, and subtracting the offsets
+		// from end also.
+		subqOffset := ng.cumulativeSubqueryOffset(path)
+		offsetMilliseconds := durationMilliseconds(subqOffset)
+		hints.Start = hints.Start - offsetMilliseconds
+
+		switch n := node.(type) {
+		case *parser.VectorSelector:
+			if evalRange == 0 {
+				hints.Start = hints.Start - durationMilliseconds(ng.lookbackDelta)
+			} else {
+				hints.Range = durationMilliseconds(evalRange)
+				// For all matrix queries we want to ensure that we have (end-start) + range selected
+				// this way we have `range` data before the start time
+				hints.Start = hints.Start - durationMilliseconds(evalRange)
+				evalRange = 0
+			}
+
+			hints.Func = extractFuncFromPath(path)
+			hints.By, hints.Grouping = extractGroupsFromPath(path)
+			if n.Offset > 0 {
+				offsetMilliseconds := durationMilliseconds(n.Offset)
+				hints.Start = hints.Start - offsetMilliseconds
+				hints.End = hints.End - offsetMilliseconds
+			}
+
+			set, wrn, err = querier.Select(false, hints, n.LabelMatchers...)
+			warnings = append(warnings, wrn...)
+			if err != nil {
+				level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)
+				return err
+			}
+			n.UnexpandedSeriesSet = set
+
+		case *parser.MatrixSelector:
+			evalRange = n.Range
+		}
+		return nil
+	})
+	return warnings, err
+}
+
+// extractFuncFromPath walks up the path and searches for the first instance of
+// a function or aggregation.
+func extractFuncFromPath(p []parser.Node) string {
+	if len(p) == 0 {
+		return ""
+	}
+	switch n := p[len(p)-1].(type) {
+	case *parser.AggregateExpr:
+		return n.Op.String()
+	case *parser.Call:
+		return n.Func.Name
+	case *parser.BinaryExpr:
+		// If we hit a binary expression we terminate since we only care about functions
+		// or aggregations over a single metric.
+		return ""
+	}
+	return extractFuncFromPath(p[:len(p)-1])
+}
+
+// extractGroupsFromPath parses vector outer function and extracts grouping information if by or without was used.
+func extractGroupsFromPath(p []parser.Node) (bool, []string) {
+	if len(p) == 0 {
+		return false, nil
+	}
+	switch n := p[len(p)-1].(type) {
+	case *parser.AggregateExpr:
+		return !n.Without, n.Grouping
+	}
+	return false, nil
+}
+
+func checkForSeriesSetExpansion(ctx context.Context, expr parser.Expr) {
+	switch e := expr.(type) {
+	case *parser.MatrixSelector:
+		checkForSeriesSetExpansion(ctx, e.VectorSelector)
+	case *parser.VectorSelector:
+		if e.Series == nil {
+			series, err := expandSeriesSet(ctx, e.UnexpandedSeriesSet)
+			if err != nil {
+				panic(err)
+			} else {
+				e.Series = series
+			}
+		}
+	}
+}
+
+func expandSeriesSet(ctx context.Context, it storage.SeriesSet) (res []storage.Series, err error) {
+	for it.Next() {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		res = append(res, it.At())
+	}
+	return res, it.Err()
+}
+
+// An evaluator evaluates given expressions over given fixed timestamps. It
+// is attached to an engine through which it connects to a querier and reports
+// errors. On timeout or cancellation of its context it terminates.
+type evaluator struct {
+	ctx context.Context
+
+	startTimestamp int64 // Start time in milliseconds.
+	endTimestamp   int64 // End time in milliseconds.
+	interval       int64 // Interval in milliseconds.
+
+	maxSamples          int
+	currentSamples      int
+	defaultEvalInterval int64
+	logger              log.Logger
+	lookbackDelta       time.Duration
+}
+
+// errorf causes a panic with the input formatted into an error.
+func (ev *evaluator) errorf(format string, args ...interface{}) {
+	ev.error(errors.Errorf(format, args...))
+}
+
+// error causes a panic with the given error.
+func (ev *evaluator) error(err error) {
+	panic(err)
+}
+
+// recover is the handler that turns panics into returns from the top level of evaluation.
+func (ev *evaluator) recover(errp *error) {
+	e := recover()
+	if e == nil {
+		return
+	}
+	if err, ok := e.(runtime.Error); ok {
+		// Print the stack trace but do not inhibit the running application.
+		buf := make([]byte, 64<<10)
+		buf = buf[:runtime.Stack(buf, false)]
+
+		level.Error(ev.logger).Log("msg", "runtime panic in parser", "err", e, "stacktrace", string(buf))
+		*errp = errors.Wrap(err, "unexpected error")
+	} else {
+		*errp = e.(error)
+	}
+}
+
+func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, err error) {
+	defer ev.recover(&err)
+	return ev.eval(expr), nil
+}
+
+// EvalNodeHelper stores extra information and caches for evaluating a single node across steps.
+type EvalNodeHelper struct {
+	// Evaluation timestamp.
+	ts int64
+	// Vector that can be used for output.
+	out Vector
+
+	// Caches.
+	// dropMetricName and label_*.
+	dmn map[uint64]labels.Labels
+	// signatureFunc.
+	sigf map[uint64]uint64
+	// funcHistogramQuantile.
+	signatureToMetricWithBuckets map[uint64]*metricWithBuckets
+	// label_replace.
+	regex *regexp.Regexp
+
+	// For binary vector matching.
+	rightSigs    map[uint64]Sample
+	matchedSigs  map[uint64]map[uint64]struct{}
+	resultMetric map[uint64]labels.Labels
+}
+
+// dropMetricName is a cached version of dropMetricName.
+func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
+	if enh.dmn == nil {
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+	h := l.Hash()
+	ret, ok := enh.dmn[h]
+	if ok {
+		return ret
+	}
+	ret = dropMetricName(l)
+	enh.dmn[h] = ret
+	return ret
+}
+
+// signatureFunc is a cached version of signatureFunc.
+func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
+	if enh.sigf == nil {
+		enh.sigf = make(map[uint64]uint64, len(enh.out))
+	}
+	f := signatureFunc(on, names...)
+	return func(l labels.Labels) uint64 {
+		h := l.Hash()
+		ret, ok := enh.sigf[h]
+		if ok {
+			return ret
+		}
+		ret = f(l)
+		enh.sigf[h] = ret
+		return ret
+	}
+}
+
+// rangeEval evaluates the given expressions, and then for each step calls
+// the given function with the values computed for each expression at that
+// step.  The return value is the combination into time series of all the
+// function call results.
+func (ev *evaluator) rangeEval(f func([]parser.Value, *EvalNodeHelper) Vector, exprs ...parser.Expr) Matrix {
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+	matrixes := make([]Matrix, len(exprs))
+	origMatrixes := make([]Matrix, len(exprs))
+	originalNumSamples := ev.currentSamples
+
+	for i, e := range exprs {
+		// Functions will take string arguments from the expressions, not the values.
+		if e != nil && e.Type() != parser.ValueTypeString {
+			// ev.currentSamples will be updated to the correct value within the ev.eval call.
+			matrixes[i] = ev.eval(e).(Matrix)
+
+			// Keep a copy of the original point slices so that they
+			// can be returned to the pool.
+			origMatrixes[i] = make(Matrix, len(matrixes[i]))
+			copy(origMatrixes[i], matrixes[i])
+		}
+	}
+
+	vectors := make([]Vector, len(exprs))    // Input vectors for the function.
+	args := make([]parser.Value, len(exprs)) // Argument to function.
+	// Create an output vector that is as big as the input matrix with
+	// the most time series.
+	biggestLen := 1
+	for i := range exprs {
+		vectors[i] = make(Vector, 0, len(matrixes[i]))
+		if len(matrixes[i]) > biggestLen {
+			biggestLen = len(matrixes[i])
+		}
+	}
+	enh := &EvalNodeHelper{out: make(Vector, 0, biggestLen)}
+	seriess := make(map[uint64]Series, biggestLen) // Output series by series hash.
+	tempNumSamples := ev.currentSamples
+	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+		if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
+			ev.error(err)
+		}
+		// Reset number of samples in memory after each timestamp.
+		ev.currentSamples = tempNumSamples
+		// Gather input vectors for this timestamp.
+		for i := range exprs {
+			vectors[i] = vectors[i][:0]
+			for si, series := range matrixes[i] {
+				for _, point := range series.Points {
+					if point.T == ts {
+						if ev.currentSamples < ev.maxSamples {
+							vectors[i] = append(vectors[i], Sample{Metric: series.Metric, Point: point})
+							// Move input vectors forward so we don't have to re-scan the same
+							// past points at the next step.
+							matrixes[i][si].Points = series.Points[1:]
+							ev.currentSamples++
+						} else {
+							ev.error(ErrTooManySamples(env))
+						}
+					}
+					break
+				}
+			}
+			args[i] = vectors[i]
+		}
+		// Make the function call.
+		enh.ts = ts
+		result := f(args, enh)
+		if result.ContainsSameLabelset() {
+			ev.errorf("vector cannot contain metrics with the same labelset")
+		}
+		enh.out = result[:0] // Reuse result vector.
+
+		ev.currentSamples += len(result)
+		// When we reset currentSamples to tempNumSamples during the next iteration of the loop it also
+		// needs to include the samples from the result here, as they're still in memory.
+		tempNumSamples += len(result)
+
+		if ev.currentSamples > ev.maxSamples {
+			ev.error(ErrTooManySamples(env))
+		}
+
+		// If this could be an instant query, shortcut so as not to change sort order.
+		if ev.endTimestamp == ev.startTimestamp {
+			mat := make(Matrix, len(result))
+			for i, s := range result {
+				s.Point.T = ts
+				mat[i] = Series{Metric: s.Metric, Points: []Point{s.Point}}
+			}
+			ev.currentSamples = originalNumSamples + mat.TotalSamples()
+			return mat
+		}
+
+		// Add samples in output vector to output series.
+		for _, sample := range result {
+			h := sample.Metric.Hash()
+			ss, ok := seriess[h]
+			if !ok {
+				ss = Series{
+					Metric: sample.Metric,
+					Points: getPointSlice(numSteps),
+				}
+			}
+			sample.Point.T = ts
+			ss.Points = append(ss.Points, sample.Point)
+			seriess[h] = ss
+
+		}
+	}
+
+	// Reuse the original point slices.
+	for _, m := range origMatrixes {
+		for _, s := range m {
+			putPointSlice(s.Points)
+		}
+	}
+	// Assemble the output matrix. By the time we get here we know we don't have too many samples.
+	mat := make(Matrix, 0, len(seriess))
+	for _, ss := range seriess {
+		mat = append(mat, ss)
+	}
+	ev.currentSamples = originalNumSamples + mat.TotalSamples()
+	return mat
+}
+
+// evalSubquery evaluates given SubqueryExpr and returns an equivalent
+// evaluated MatrixSelector in its place. Note that the Name and LabelMatchers are not set.
+func (ev *evaluator) evalSubquery(subq *parser.SubqueryExpr) *parser.MatrixSelector {
+	val := ev.eval(subq).(Matrix)
+	vs := &parser.VectorSelector{
+		Offset: subq.Offset,
+		Series: make([]storage.Series, 0, len(val)),
+	}
+	ms := &parser.MatrixSelector{
+		Range:          subq.Range,
+		VectorSelector: vs,
+	}
+	for _, s := range val {
+		vs.Series = append(vs.Series, NewStorageSeries(s))
+	}
+	return ms
+}
+
+// eval evaluates the given expression as the given AST expression node requires.
+func (ev *evaluator) eval(expr parser.Expr) parser.Value {
+	// This is the top-level evaluation method.
+	// Thus, we check for timeout/cancellation here.
+	if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
+		ev.error(err)
+	}
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+
+	switch e := expr.(type) {
+	case *parser.AggregateExpr:
+		unwrapParenExpr(&e.Param)
+		if s, ok := e.Param.(*parser.StringLiteral); ok {
+			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+				return ev.aggregation(e.Op, e.Grouping, e.Without, s.Val, v[0].(Vector), enh)
+			}, e.Expr)
+		}
+		return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+			var param float64
+			if e.Param != nil {
+				param = v[0].(Vector)[0].V
+			}
+			return ev.aggregation(e.Op, e.Grouping, e.Without, param, v[1].(Vector), enh)
+		}, e.Param, e.Expr)
+
+	case *parser.Call:
+		call := FunctionCalls[e.Func.Name]
+
+		if e.Func.Name == "timestamp" {
+			// Matrix evaluation always returns the evaluation time,
+			// so this function needs special handling when given
+			// a vector selector.
+			vs, ok := e.Args[0].(*parser.VectorSelector)
+			if ok {
+				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+					return call([]parser.Value{ev.vectorSelector(vs, enh.ts)}, e.Args, enh)
+				})
+			}
+		}
+
+		// Check if the function has a matrix argument.
+		var matrixArgIndex int
+		var matrixArg bool
+		for i := range e.Args {
+			unwrapParenExpr(&e.Args[i])
+			a := e.Args[i]
+			if _, ok := a.(*parser.MatrixSelector); ok {
+				matrixArgIndex = i
+				matrixArg = true
+				break
+			}
+			// parser.SubqueryExpr can be used in place of parser.MatrixSelector.
+			if subq, ok := a.(*parser.SubqueryExpr); ok {
+				matrixArgIndex = i
+				matrixArg = true
+				// Replacing parser.SubqueryExpr with parser.MatrixSelector.
+				e.Args[i] = ev.evalSubquery(subq)
+				break
+			}
+		}
+		if !matrixArg {
+			// Does not have a matrix argument.
+			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+				return call(v, e.Args, enh)
+			}, e.Args...)
+		}
+
+		inArgs := make([]parser.Value, len(e.Args))
+		// Evaluate any non-matrix arguments.
+		otherArgs := make([]Matrix, len(e.Args))
+		otherInArgs := make([]Vector, len(e.Args))
+		for i, e := range e.Args {
+			if i != matrixArgIndex {
+				otherArgs[i] = ev.eval(e).(Matrix)
+				otherInArgs[i] = Vector{Sample{}}
+				inArgs[i] = otherInArgs[i]
+			}
+		}
+
+		sel := e.Args[matrixArgIndex].(*parser.MatrixSelector)
+		selVS := sel.VectorSelector.(*parser.VectorSelector)
+
+		checkForSeriesSetExpansion(ev.ctx, sel)
+		mat := make(Matrix, 0, len(selVS.Series)) // Output matrix.
+		offset := durationMilliseconds(selVS.Offset)
+		selRange := durationMilliseconds(sel.Range)
+		stepRange := selRange
+		if stepRange > ev.interval {
+			stepRange = ev.interval
+		}
+		// Reuse objects across steps to save memory allocations.
+		points := getPointSlice(16)
+		inMatrix := make(Matrix, 1)
+		inArgs[matrixArgIndex] = inMatrix
+		enh := &EvalNodeHelper{out: make(Vector, 0, 1)}
+		// Process all the calls for one time series at a time.
+		it := storage.NewBuffer(selRange)
+		for i, s := range selVS.Series {
+			points = points[:0]
+			it.Reset(s.Iterator())
+			ss := Series{
+				// For all range vector functions, the only change to the
+				// output labels is dropping the metric name so just do
+				// it once here.
+				Metric: dropMetricName(selVS.Series[i].Labels()),
+				Points: getPointSlice(numSteps),
+			}
+			inMatrix[0].Metric = selVS.Series[i].Labels()
+			for ts, step := ev.startTimestamp, -1; ts <= ev.endTimestamp; ts += ev.interval {
+				step++
+				// Set the non-matrix arguments.
+				// They are scalar, so it is safe to use the step number
+				// when looking up the argument, as there will be no gaps.
+				for j := range e.Args {
+					if j != matrixArgIndex {
+						otherInArgs[j][0].V = otherArgs[j][0].Points[step].V
+					}
+				}
+				maxt := ts - offset
+				mint := maxt - selRange
+				// Evaluate the matrix selector for this series for this step.
+				points = ev.matrixIterSlice(it, mint, maxt, points)
+				if len(points) == 0 {
+					continue
+				}
+				inMatrix[0].Points = points
+				enh.ts = ts
+				// Make the function call.
+				outVec := call(inArgs, e.Args, enh)
+				enh.out = outVec[:0]
+				if len(outVec) > 0 {
+					ss.Points = append(ss.Points, Point{V: outVec[0].Point.V, T: ts})
+				}
+				// Only buffer stepRange milliseconds from the second step on.
+				it.ReduceDelta(stepRange)
+			}
+			if len(ss.Points) > 0 {
+				if ev.currentSamples < ev.maxSamples {
+					mat = append(mat, ss)
+					ev.currentSamples += len(ss.Points)
+				} else {
+					ev.error(ErrTooManySamples(env))
+				}
+			} else {
+				putPointSlice(ss.Points)
+			}
+		}
+
+		putPointSlice(points)
+
+		// The absent_over_time function returns 0 or 1 series. So far, the matrix
+		// contains multiple series. The following code will create a new series
+		// with values of 1 for the timestamps where no series has value.
+		if e.Func.Name == "absent_over_time" {
+			steps := int(1 + (ev.endTimestamp-ev.startTimestamp)/ev.interval)
+			// Iterate once to look for a complete series.
+			for _, s := range mat {
+				if len(s.Points) == steps {
+					return Matrix{}
+				}
+			}
+
+			found := map[int64]struct{}{}
+
+			for i, s := range mat {
+				for _, p := range s.Points {
+					found[p.T] = struct{}{}
+				}
+				if i > 0 && len(found) == steps {
+					return Matrix{}
+				}
+			}
+
+			newp := make([]Point, 0, steps-len(found))
+			for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+				if _, ok := found[ts]; !ok {
+					newp = append(newp, Point{T: ts, V: 1})
+				}
+			}
+
+			return Matrix{
+				Series{
+					Metric: createLabelsForAbsentFunction(e.Args[0]),
+					Points: newp,
+				},
+			}
+		}
+
+		if mat.ContainsSameLabelset() {
+			ev.errorf("vector cannot contain metrics with the same labelset")
+		}
+
+		return mat
+
+	case *parser.ParenExpr:
+		return ev.eval(e.Expr)
+
+	case *parser.UnaryExpr:
+		mat := ev.eval(e.Expr).(Matrix)
+		if e.Op == parser.SUB {
+			for i := range mat {
+				mat[i].Metric = dropMetricName(mat[i].Metric)
+				for j := range mat[i].Points {
+					mat[i].Points[j].V = -mat[i].Points[j].V
+				}
+			}
+			if mat.ContainsSameLabelset() {
+				ev.errorf("vector cannot contain metrics with the same labelset")
+			}
+		}
+		return mat
+
+	case *parser.BinaryExpr:
+		switch lt, rt := e.LHS.Type(), e.RHS.Type(); {
+		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeScalar:
+			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+				val := scalarBinop(e.Op, v[0].(Vector)[0].Point.V, v[1].(Vector)[0].Point.V)
+				return append(enh.out, Sample{Point: Point{V: val}})
+			}, e.LHS, e.RHS)
+		case lt == parser.ValueTypeVector && rt == parser.ValueTypeVector:
+			switch e.Op {
+			case parser.LAND:
+				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorAnd(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			case parser.LOR:
+				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorOr(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			case parser.LUNLESS:
+				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorUnless(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			default:
+				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorBinop(e.Op, v[0].(Vector), v[1].(Vector), e.VectorMatching, e.ReturnBool, enh)
+				}, e.LHS, e.RHS)
+			}
+
+		case lt == parser.ValueTypeVector && rt == parser.ValueTypeScalar:
+			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+				return ev.VectorscalarBinop(e.Op, v[0].(Vector), Scalar{V: v[1].(Vector)[0].Point.V}, false, e.ReturnBool, enh)
+			}, e.LHS, e.RHS)
+
+		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeVector:
+			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+				return ev.VectorscalarBinop(e.Op, v[1].(Vector), Scalar{V: v[0].(Vector)[0].Point.V}, true, e.ReturnBool, enh)
+			}, e.LHS, e.RHS)
+		}
+
+	case *parser.NumberLiteral:
+		return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) Vector {
+			return append(enh.out, Sample{Point: Point{V: e.Val}})
+		})
+
+	case *parser.VectorSelector:
+		checkForSeriesSetExpansion(ev.ctx, e)
+		mat := make(Matrix, 0, len(e.Series))
+		it := storage.NewBuffer(durationMilliseconds(ev.lookbackDelta))
+		for i, s := range e.Series {
+			it.Reset(s.Iterator())
+			ss := Series{
+				Metric: e.Series[i].Labels(),
+				Points: getPointSlice(numSteps),
+			}
+
+			for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+				_, v, ok := ev.vectorSelectorSingle(it, e, ts)
+				if ok {
+					if ev.currentSamples < ev.maxSamples {
+						ss.Points = append(ss.Points, Point{V: v, T: ts})
+						ev.currentSamples++
+					} else {
+						ev.error(ErrTooManySamples(env))
+					}
+				}
+			}
+
+			if len(ss.Points) > 0 {
+				mat = append(mat, ss)
+			} else {
+				putPointSlice(ss.Points)
+			}
+
+		}
+		return mat
+
+	case *parser.MatrixSelector:
+		if ev.startTimestamp != ev.endTimestamp {
+			panic(errors.New("cannot do range evaluation of matrix selector"))
+		}
+		return ev.matrixSelector(e)
+
+	case *parser.SubqueryExpr:
+		offsetMillis := durationToInt64Millis(e.Offset)
+		rangeMillis := durationToInt64Millis(e.Range)
+		newEv := &evaluator{
+			endTimestamp:        ev.endTimestamp - offsetMillis,
+			interval:            ev.defaultEvalInterval,
+			ctx:                 ev.ctx,
+			currentSamples:      ev.currentSamples,
+			maxSamples:          ev.maxSamples,
+			defaultEvalInterval: ev.defaultEvalInterval,
+			logger:              ev.logger,
+			lookbackDelta:       ev.lookbackDelta,
+		}
+
+		if e.Step != 0 {
+			newEv.interval = durationToInt64Millis(e.Step)
+		}
+
+		// Start with the first timestamp after (ev.startTimestamp - offset - range)
+		// that is aligned with the step (multiple of 'newEv.interval').
+		newEv.startTimestamp = newEv.interval * ((ev.startTimestamp - offsetMillis - rangeMillis) / newEv.interval)
+		if newEv.startTimestamp < (ev.startTimestamp - offsetMillis - rangeMillis) {
+			newEv.startTimestamp += newEv.interval
+		}
+
+		res := newEv.eval(e.Expr)
+		ev.currentSamples = newEv.currentSamples
+		return res
+	case *parser.StringLiteral:
+		return String{V: e.Val, T: ev.startTimestamp}
+	}
+
+	panic(errors.Errorf("unhandled expression of type: %T", expr))
+}
+
+func durationToInt64Millis(d time.Duration) int64 {
+	return int64(d / time.Millisecond)
+}
+
+// vectorSelector evaluates a *parser.VectorSelector expression.
+func (ev *evaluator) vectorSelector(node *parser.VectorSelector, ts int64) Vector {
+	checkForSeriesSetExpansion(ev.ctx, node)
+
+	var (
+		vec = make(Vector, 0, len(node.Series))
+	)
+
+	it := storage.NewBuffer(durationMilliseconds(ev.lookbackDelta))
+	for i, s := range node.Series {
+		it.Reset(s.Iterator())
+
+		t, v, ok := ev.vectorSelectorSingle(it, node, ts)
+		if ok {
+			vec = append(vec, Sample{
+				Metric: node.Series[i].Labels(),
+				Point:  Point{V: v, T: t},
+			})
+			ev.currentSamples++
+		}
+
+		if ev.currentSamples >= ev.maxSamples {
+			ev.error(ErrTooManySamples(env))
+		}
+	}
+	return vec
+}
+
+// vectorSelectorSingle evaluates a instant vector for the iterator of one time series.
+func (ev *evaluator) vectorSelectorSingle(it *storage.BufferedSeriesIterator, node *parser.VectorSelector, ts int64) (int64, float64, bool) {
+	refTime := ts - durationMilliseconds(node.Offset)
+	var t int64
+	var v float64
+
+	ok := it.Seek(refTime)
+	if !ok {
+		if it.Err() != nil {
+			ev.error(it.Err())
+		}
+	}
+
+	if ok {
+		t, v = it.Values()
+	}
+
+	if !ok || t > refTime {
+		t, v, ok = it.PeekBack(1)
+		if !ok || t < refTime-durationMilliseconds(ev.lookbackDelta) {
+			return 0, 0, false
+		}
+	}
+	if value.IsStaleNaN(v) {
+		return 0, 0, false
+	}
+	return t, v, true
+}
+
+var pointPool = sync.Pool{}
+
+func getPointSlice(sz int) []Point {
+	p := pointPool.Get()
+	if p != nil {
+		return p.([]Point)
+	}
+	return make([]Point, 0, sz)
+}
+
+func putPointSlice(p []Point) {
+	//lint:ignore SA6002 relax staticcheck verification.
+	pointPool.Put(p[:0])
+}
+
+// matrixSelector evaluates a *parser.MatrixSelector expression.
+func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) Matrix {
+	checkForSeriesSetExpansion(ev.ctx, node)
+
+	vs := node.VectorSelector.(*parser.VectorSelector)
+
+	var (
+		offset = durationMilliseconds(vs.Offset)
+		maxt   = ev.startTimestamp - offset
+		mint   = maxt - durationMilliseconds(node.Range)
+		matrix = make(Matrix, 0, len(vs.Series))
+	)
+
+	it := storage.NewBuffer(durationMilliseconds(node.Range))
+	series := vs.Series
+
+	for i, s := range series {
+		if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
+			ev.error(err)
+		}
+		it.Reset(s.Iterator())
+		ss := Series{
+			Metric: series[i].Labels(),
+		}
+
+		ss.Points = ev.matrixIterSlice(it, mint, maxt, getPointSlice(16))
+
+		if len(ss.Points) > 0 {
+			matrix = append(matrix, ss)
+		} else {
+			putPointSlice(ss.Points)
+		}
+	}
+	return matrix
+}
+
+// matrixIterSlice populates a matrix vector covering the requested range for a
+// single time series, with points retrieved from an iterator.
+//
+// As an optimization, the matrix vector may already contain points of the same
+// time series from the evaluation of an earlier step (with lower mint and maxt
+// values). Any such points falling before mint are discarded; points that fall
+// into the [mint, maxt] range are retained; only points with later timestamps
+// are populated from the iterator.
+func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Point) []Point {
+	if len(out) > 0 && out[len(out)-1].T >= mint {
+		// There is an overlap between previous and current ranges, retain common
+		// points. In most such cases:
+		//   (a) the overlap is significantly larger than the eval step; and/or
+		//   (b) the number of samples is relatively small.
+		// so a linear search will be as fast as a binary search.
+		var drop int
+		for drop = 0; out[drop].T < mint; drop++ {
+		}
+		copy(out, out[drop:])
+		out = out[:len(out)-drop]
+		// Only append points with timestamps after the last timestamp we have.
+		mint = out[len(out)-1].T + 1
+	} else {
+		out = out[:0]
+	}
+
+	ok := it.Seek(maxt)
+	if !ok {
+		if it.Err() != nil {
+			ev.error(it.Err())
+		}
+	}
+
+	buf := it.Buffer()
+	for buf.Next() {
+		t, v := buf.At()
+		if value.IsStaleNaN(v) {
+			continue
+		}
+		// Values in the buffer are guaranteed to be smaller than maxt.
+		if t >= mint {
+			if ev.currentSamples >= ev.maxSamples {
+				ev.error(ErrTooManySamples(env))
+			}
+			out = append(out, Point{T: t, V: v})
+			ev.currentSamples++
+		}
+	}
+	// The seeked sample might also be in the range.
+	if ok {
+		t, v := it.Values()
+		if t == maxt && !value.IsStaleNaN(v) {
+			if ev.currentSamples >= ev.maxSamples {
+				ev.error(ErrTooManySamples(env))
+			}
+			out = append(out, Point{T: t, V: v})
+			ev.currentSamples++
+		}
+	}
+	return out
+}
+
+func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != parser.CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	// The set of signatures for the right-hand side Vector.
+	rightSigs := map[uint64]struct{}{}
+	// Add all rhs samples to a map so we can easily find matches later.
+	for _, rs := range rhs {
+		rightSigs[sigf(rs.Metric)] = struct{}{}
+	}
+
+	for _, ls := range lhs {
+		// If there's a matching entry in the right-hand side Vector, add the sample.
+		if _, ok := rightSigs[sigf(ls.Metric)]; ok {
+			enh.out = append(enh.out, ls)
+		}
+	}
+	return enh.out
+}
+
+func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != parser.CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	leftSigs := map[uint64]struct{}{}
+	// Add everything from the left-hand-side Vector.
+	for _, ls := range lhs {
+		leftSigs[sigf(ls.Metric)] = struct{}{}
+		enh.out = append(enh.out, ls)
+	}
+	// Add all right-hand side elements which have not been added from the left-hand side.
+	for _, rs := range rhs {
+		if _, ok := leftSigs[sigf(rs.Metric)]; !ok {
+			enh.out = append(enh.out, rs)
+		}
+	}
+	return enh.out
+}
+
+func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != parser.CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	rightSigs := map[uint64]struct{}{}
+	for _, rs := range rhs {
+		rightSigs[sigf(rs.Metric)] = struct{}{}
+	}
+
+	for _, ls := range lhs {
+		if _, ok := rightSigs[sigf(ls.Metric)]; !ok {
+			enh.out = append(enh.out, ls)
+		}
+	}
+	return enh.out
+}
+
+// VectorBinop evaluates a binary operation between two Vectors, excluding set operators.
+func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *parser.VectorMatching, returnBool bool, enh *EvalNodeHelper) Vector {
+	if matching.Card == parser.CardManyToMany {
+		panic("many-to-many only allowed for set operators")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	// The control flow below handles one-to-one or many-to-one matching.
+	// For one-to-many, swap sidedness and account for the swap when calculating
+	// values.
+	if matching.Card == parser.CardOneToMany {
+		lhs, rhs = rhs, lhs
+	}
+
+	// All samples from the rhs hashed by the matching label/values.
+	if enh.rightSigs == nil {
+		enh.rightSigs = make(map[uint64]Sample, len(enh.out))
+	} else {
+		for k := range enh.rightSigs {
+			delete(enh.rightSigs, k)
+		}
+	}
+	rightSigs := enh.rightSigs
+
+	// Add all rhs samples to a map so we can easily find matches later.
+	for _, rs := range rhs {
+		sig := sigf(rs.Metric)
+		// The rhs is guaranteed to be the 'one' side. Having multiple samples
+		// with the same signature means that the matching is many-to-many.
+		if duplSample, found := rightSigs[sig]; found {
+			// oneSide represents which side of the vector represents the 'one' in the many-to-one relationship.
+			oneSide := "right"
+			if matching.Card == parser.CardOneToMany {
+				oneSide = "left"
+			}
+			matchedLabels := rs.Metric.MatchLabels(matching.On, matching.MatchingLabels...)
+			// Many-to-many matching not allowed.
+			ev.errorf("found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]"+
+				";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, rs.Metric.String(), duplSample.Metric.String())
+		}
+		rightSigs[sig] = rs
+	}
+
+	// Tracks the match-signature. For one-to-one operations the value is nil. For many-to-one
+	// the value is a set of signatures to detect duplicated result elements.
+	if enh.matchedSigs == nil {
+		enh.matchedSigs = make(map[uint64]map[uint64]struct{}, len(rightSigs))
+	} else {
+		for k := range enh.matchedSigs {
+			delete(enh.matchedSigs, k)
+		}
+	}
+	matchedSigs := enh.matchedSigs
+
+	// For all lhs samples find a respective rhs sample and perform
+	// the binary operation.
+	for _, ls := range lhs {
+		sig := sigf(ls.Metric)
+
+		rs, found := rightSigs[sig] // Look for a match in the rhs Vector.
+		if !found {
+			continue
+		}
+
+		// Account for potentially swapped sidedness.
+		vl, vr := ls.V, rs.V
+		if matching.Card == parser.CardOneToMany {
+			vl, vr = vr, vl
+		}
+		value, keep := vectorElemBinop(op, vl, vr)
+		if returnBool {
+			if keep {
+				value = 1.0
+			} else {
+				value = 0.0
+			}
+		} else if !keep {
+			continue
+		}
+		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
+
+		insertedSigs, exists := matchedSigs[sig]
+		if matching.Card == parser.CardOneToOne {
+			if exists {
+				ev.errorf("multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)")
+			}
+			matchedSigs[sig] = nil // Set existence to true.
+		} else {
+			// In many-to-one matching the grouping labels have to ensure a unique metric
+			// for the result Vector. Check whether those labels have already been added for
+			// the same matching labels.
+			insertSig := metric.Hash()
+
+			if !exists {
+				insertedSigs = map[uint64]struct{}{}
+				matchedSigs[sig] = insertedSigs
+			} else if _, duplicate := insertedSigs[insertSig]; duplicate {
+				ev.errorf("multiple matches for labels: grouping labels must ensure unique matches")
+			}
+			insertedSigs[insertSig] = struct{}{}
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: metric,
+			Point:  Point{V: value},
+		})
+	}
+	return enh.out
+}
+
+// signatureFunc returns a function that calculates the signature for a metric
+// ignoring the provided labels. If on, then the given labels are only used instead.
+func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
+	sort.Strings(names)
+	if on {
+		return func(lset labels.Labels) uint64 {
+			h, _ := lset.HashForLabels(make([]byte, 0, 1024), names...)
+			return h
+		}
+	}
+	return func(lset labels.Labels) uint64 {
+		h, _ := lset.HashWithoutLabels(make([]byte, 0, 1024), names...)
+		return h
+	}
+}
+
+// resultMetric returns the metric for the given sample(s) based on the Vector
+// binary operation and the matching options.
+func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.VectorMatching, enh *EvalNodeHelper) labels.Labels {
+	if enh.resultMetric == nil {
+		enh.resultMetric = make(map[uint64]labels.Labels, len(enh.out))
+	}
+	// op and matching are always the same for a given node, so
+	// there's no need to include them in the hash key.
+	// If the lhs and rhs are the same then the xor would be 0,
+	// so add in one side to protect against that.
+	lh := lhs.Hash()
+	h := (lh ^ rhs.Hash()) + lh
+	if ret, ok := enh.resultMetric[h]; ok {
+		return ret
+	}
+
+	lb := labels.NewBuilder(lhs)
+
+	if shouldDropMetricName(op) {
+		lb.Del(labels.MetricName)
+	}
+
+	if matching.Card == parser.CardOneToOne {
+		if matching.On {
+		Outer:
+			for _, l := range lhs {
+				for _, n := range matching.MatchingLabels {
+					if l.Name == n {
+						continue Outer
+					}
+				}
+				lb.Del(l.Name)
+			}
+		} else {
+			lb.Del(matching.MatchingLabels...)
+		}
+	}
+	for _, ln := range matching.Include {
+		// Included labels from the `group_x` modifier are taken from the "one"-side.
+		if v := rhs.Get(ln); v != "" {
+			lb.Set(ln, v)
+		} else {
+			lb.Del(ln)
+		}
+	}
+
+	ret := lb.Labels()
+	enh.resultMetric[h] = ret
+	return ret
+}
+
+// VectorscalarBinop evaluates a binary operation between a Vector and a Scalar.
+func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scalar, swap, returnBool bool, enh *EvalNodeHelper) Vector {
+	for _, lhsSample := range lhs {
+		lv, rv := lhsSample.V, rhs.V
+		// lhs always contains the Vector. If the original position was different
+		// swap for calculating the value.
+		if swap {
+			lv, rv = rv, lv
+		}
+		value, keep := vectorElemBinop(op, lv, rv)
+		// Catch cases where the scalar is the LHS in a scalar-vector comparison operation.
+		// We want to always keep the vector element value as the output value, even if it's on the RHS.
+		if op.IsComparisonOperator() && swap {
+			value = rv
+		}
+		if returnBool {
+			if keep {
+				value = 1.0
+			} else {
+				value = 0.0
+			}
+			keep = true
+		}
+		if keep {
+			lhsSample.V = value
+			if shouldDropMetricName(op) || returnBool {
+				lhsSample.Metric = enh.dropMetricName(lhsSample.Metric)
+			}
+			enh.out = append(enh.out, lhsSample)
+		}
+	}
+	return enh.out
+}
+
+func dropMetricName(l labels.Labels) labels.Labels {
+	return labels.NewBuilder(l).Del(labels.MetricName).Labels()
+}
+
+// scalarBinop evaluates a binary operation between two Scalars.
+func scalarBinop(op parser.ItemType, lhs, rhs float64) float64 {
+	switch op {
+	case parser.ADD:
+		return lhs + rhs
+	case parser.SUB:
+		return lhs - rhs
+	case parser.MUL:
+		return lhs * rhs
+	case parser.DIV:
+		return lhs / rhs
+	case parser.POW:
+		return math.Pow(lhs, rhs)
+	case parser.MOD:
+		return math.Mod(lhs, rhs)
+	case parser.EQL:
+		return btos(lhs == rhs)
+	case parser.NEQ:
+		return btos(lhs != rhs)
+	case parser.GTR:
+		return btos(lhs > rhs)
+	case parser.LSS:
+		return btos(lhs < rhs)
+	case parser.GTE:
+		return btos(lhs >= rhs)
+	case parser.LTE:
+		return btos(lhs <= rhs)
+	}
+	panic(errors.Errorf("operator %q not allowed for Scalar operations", op))
+}
+
+// vectorElemBinop evaluates a binary operation between two Vector elements.
+func vectorElemBinop(op parser.ItemType, lhs, rhs float64) (float64, bool) {
+	switch op {
+	case parser.ADD:
+		return lhs + rhs, true
+	case parser.SUB:
+		return lhs - rhs, true
+	case parser.MUL:
+		return lhs * rhs, true
+	case parser.DIV:
+		return lhs / rhs, true
+	case parser.POW:
+		return math.Pow(lhs, rhs), true
+	case parser.MOD:
+		return math.Mod(lhs, rhs), true
+	case parser.EQL:
+		return lhs, lhs == rhs
+	case parser.NEQ:
+		return lhs, lhs != rhs
+	case parser.GTR:
+		return lhs, lhs > rhs
+	case parser.LSS:
+		return lhs, lhs < rhs
+	case parser.GTE:
+		return lhs, lhs >= rhs
+	case parser.LTE:
+		return lhs, lhs <= rhs
+	}
+	panic(errors.Errorf("operator %q not allowed for operations between Vectors", op))
+}
+
+type groupedAggregation struct {
+	labels      labels.Labels
+	value       float64
+	mean        float64
+	groupCount  int
+	heap        vectorByValueHeap
+	reverseHeap vectorByReverseValueHeap
+}
+
+// aggregation evaluates an aggregation operation on a Vector.
+func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without bool, param interface{}, vec Vector, enh *EvalNodeHelper) Vector {
+
+	result := map[uint64]*groupedAggregation{}
+	var k int64
+	if op == parser.TOPK || op == parser.BOTTOMK {
+		f := param.(float64)
+		if !convertibleToInt64(f) {
+			ev.errorf("Scalar value %v overflows int64", f)
+		}
+		k = int64(f)
+		if k < 1 {
+			return Vector{}
+		}
+	}
+	var q float64
+	if op == parser.QUANTILE {
+		q = param.(float64)
+	}
+	var valueLabel string
+	if op == parser.COUNT_VALUES {
+		valueLabel = param.(string)
+		if !model.LabelName(valueLabel).IsValid() {
+			ev.errorf("invalid label name %q", valueLabel)
+		}
+		if !without {
+			grouping = append(grouping, valueLabel)
+		}
+	}
+
+	sort.Strings(grouping)
+	lb := labels.NewBuilder(nil)
+	buf := make([]byte, 0, 1024)
+	for _, s := range vec {
+		metric := s.Metric
+
+		if op == parser.COUNT_VALUES {
+			lb.Reset(metric)
+			lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
+			metric = lb.Labels()
+		}
+
+		var (
+			groupingKey uint64
+		)
+		if without {
+			groupingKey, buf = metric.HashWithoutLabels(buf, grouping...)
+		} else {
+			groupingKey, buf = metric.HashForLabels(buf, grouping...)
+		}
+
+		group, ok := result[groupingKey]
+		// Add a new group if it doesn't exist.
+		if !ok {
+			var m labels.Labels
+
+			if without {
+				lb.Reset(metric)
+				lb.Del(grouping...)
+				lb.Del(labels.MetricName)
+				m = lb.Labels()
+			} else {
+				m = make(labels.Labels, 0, len(grouping))
+				for _, l := range metric {
+					for _, n := range grouping {
+						if l.Name == n {
+							m = append(m, l)
+							break
+						}
+					}
+				}
+				sort.Sort(m)
+			}
+			result[groupingKey] = &groupedAggregation{
+				labels:     m,
+				value:      s.V,
+				mean:       s.V,
+				groupCount: 1,
+			}
+			inputVecLen := int64(len(vec))
+			resultSize := k
+			if k > inputVecLen {
+				resultSize = inputVecLen
+			}
+			if op == parser.STDVAR || op == parser.STDDEV {
+				result[groupingKey].value = 0.0
+			} else if op == parser.TOPK || op == parser.QUANTILE {
+				result[groupingKey].heap = make(vectorByValueHeap, 0, resultSize)
+				heap.Push(&result[groupingKey].heap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			} else if op == parser.BOTTOMK {
+				result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 0, resultSize)
+				heap.Push(&result[groupingKey].reverseHeap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+			continue
+		}
+
+		switch op {
+		case parser.SUM:
+			group.value += s.V
+
+		case parser.AVG:
+			group.groupCount++
+			group.mean += (s.V - group.mean) / float64(group.groupCount)
+
+		case parser.MAX:
+			if group.value < s.V || math.IsNaN(group.value) {
+				group.value = s.V
+			}
+
+		case parser.MIN:
+			if group.value > s.V || math.IsNaN(group.value) {
+				group.value = s.V
+			}
+
+		case parser.COUNT, parser.COUNT_VALUES:
+			group.groupCount++
+
+		case parser.STDVAR, parser.STDDEV:
+			group.groupCount++
+			delta := s.V - group.mean
+			group.mean += delta / float64(group.groupCount)
+			group.value += delta * (s.V - group.mean)
+
+		case parser.TOPK:
+			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
+				if int64(len(group.heap)) == k {
+					heap.Pop(&group.heap)
+				}
+				heap.Push(&group.heap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+
+		case parser.BOTTOMK:
+			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
+				if int64(len(group.reverseHeap)) == k {
+					heap.Pop(&group.reverseHeap)
+				}
+				heap.Push(&group.reverseHeap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+
+		case parser.QUANTILE:
+			group.heap = append(group.heap, s)
+
+		default:
+			panic(errors.Errorf("expected aggregation operator but got %q", op))
+		}
+	}
+
+	// Construct the result Vector from the aggregated groups.
+	for _, aggr := range result {
+		switch op {
+		case parser.AVG:
+			aggr.value = aggr.mean
+
+		case parser.COUNT, parser.COUNT_VALUES:
+			aggr.value = float64(aggr.groupCount)
+
+		case parser.STDVAR:
+			aggr.value = aggr.value / float64(aggr.groupCount)
+
+		case parser.STDDEV:
+			aggr.value = math.Sqrt(aggr.value / float64(aggr.groupCount))
+
+		case parser.TOPK:
+			// The heap keeps the lowest value on top, so reverse it.
+			sort.Sort(sort.Reverse(aggr.heap))
+			for _, v := range aggr.heap {
+				enh.out = append(enh.out, Sample{
+					Metric: v.Metric,
+					Point:  Point{V: v.V},
+				})
+			}
+			continue // Bypass default append.
+
+		case parser.BOTTOMK:
+			// The heap keeps the lowest value on top, so reverse it.
+			sort.Sort(sort.Reverse(aggr.reverseHeap))
+			for _, v := range aggr.reverseHeap {
+				enh.out = append(enh.out, Sample{
+					Metric: v.Metric,
+					Point:  Point{V: v.V},
+				})
+			}
+			continue // Bypass default append.
+
+		case parser.QUANTILE:
+			aggr.value = quantile(q, aggr.heap)
+
+		default:
+			// For other aggregations, we already have the right value.
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: aggr.labels,
+			Point:  Point{V: aggr.value},
+		})
+	}
+	return enh.out
+}
+
+// btos returns 1 if b is true, 0 otherwise.
+func btos(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// shouldDropMetricName returns whether the metric name should be dropped in the
+// result of the op operation.
+func shouldDropMetricName(op parser.ItemType) bool {
+	switch op {
+	case parser.ADD, parser.SUB, parser.DIV, parser.MUL, parser.POW, parser.MOD:
+		return true
+	default:
+		return false
+	}
+}
+
+// NewOriginContext returns a new context with data about the origin attached.
+func NewOriginContext(ctx context.Context, data map[string]interface{}) context.Context {
+	return context.WithValue(ctx, queryOrigin{}, data)
+}
+
+func formatDate(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05.000Z07:00")
+}
+
+// unwrapParenExpr does the AST equivalent of removing parentheses around a expression.
+func unwrapParenExpr(e *parser.Expr) {
+	for {
+		if p, ok := (*e).(*parser.ParenExpr); ok {
+			*e = p.Expr
+		} else {
+			break
+		}
+	}
+}

--- a/pkg/promql/engine_test.go
+++ b/pkg/promql/engine_test.go
@@ -1,0 +1,1239 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestQueryConcurrency(t *testing.T) {
+	maxConcurrency := 10
+
+	dir, err := ioutil.TempDir("", "test_concurrency")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+	queryTracker := NewActiveQueryTracker(dir, maxConcurrency, nil)
+
+	opts := EngineOpts{
+		Logger:             nil,
+		Reg:                nil,
+		MaxSamples:         10,
+		Timeout:            100 * time.Second,
+		ActiveQueryTracker: queryTracker,
+	}
+
+	engine := NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	block := make(chan struct{})
+	processing := make(chan struct{})
+
+	f := func(context.Context) error {
+		processing <- struct{}{}
+		<-block
+		return nil
+	}
+
+	for i := 0; i < maxConcurrency; i++ {
+		q := engine.newTestQuery(f)
+		go q.Exec(ctx)
+		select {
+		case <-processing:
+			// Expected.
+		case <-time.After(20 * time.Millisecond):
+			t.Fatalf("Query within concurrency threshold not being executed")
+		}
+	}
+
+	q := engine.newTestQuery(f)
+	go q.Exec(ctx)
+
+	select {
+	case <-processing:
+		t.Fatalf("Query above concurrency threshold being executed")
+	case <-time.After(20 * time.Millisecond):
+		// Expected.
+	}
+
+	// Terminate a running query.
+	block <- struct{}{}
+
+	select {
+	case <-processing:
+		// Expected.
+	case <-time.After(20 * time.Millisecond):
+		t.Fatalf("Query within concurrency threshold not being executed")
+	}
+
+	// Terminate remaining queries.
+	for i := 0; i < maxConcurrency; i++ {
+		block <- struct{}{}
+	}
+}
+
+func TestQueryTimeout(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    5 * time.Millisecond,
+	}
+	engine := NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	query := engine.newTestQuery(func(ctx context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		return contextDone(ctx, "test statement execution")
+	})
+
+	res := query.Exec(ctx)
+	testutil.NotOk(t, res.Err, "expected timeout error but got none")
+
+	var e ErrQueryTimeout
+	// TODO: when circleci-windows moves to go 1.13:
+	// testutil.Assert(t, errors.As(res.Err, &e), "expected timeout error but got: %s", res.Err)
+	testutil.Assert(t, strings.HasPrefix(res.Err.Error(), e.Error()), "expected timeout error but got: %s", res.Err)
+}
+
+const errQueryCanceled = ErrQueryCanceled("test statement execution")
+
+func TestQueryCancel(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	// Cancel a running query before it completes.
+	block := make(chan struct{})
+	processing := make(chan struct{})
+
+	query1 := engine.newTestQuery(func(ctx context.Context) error {
+		processing <- struct{}{}
+		<-block
+		return contextDone(ctx, "test statement execution")
+	})
+
+	var res *Result
+
+	go func() {
+		res = query1.Exec(ctx)
+		processing <- struct{}{}
+	}()
+
+	<-processing
+	query1.Cancel()
+	block <- struct{}{}
+	<-processing
+
+	testutil.NotOk(t, res.Err, "expected cancellation error for query1 but got none")
+	testutil.Equals(t, errQueryCanceled, res.Err)
+
+	// Canceling a query before starting it must have no effect.
+	query2 := engine.newTestQuery(func(ctx context.Context) error {
+		return contextDone(ctx, "test statement execution")
+	})
+
+	query2.Cancel()
+	res = query2.Exec(ctx)
+	testutil.Ok(t, res.Err)
+}
+
+// errQuerier implements storage.Querier which always returns error.
+type errQuerier struct {
+	err error
+}
+
+func (q *errQuerier) Select(bool, *storage.SelectHints, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return errSeriesSet{err: q.err}, nil, q.err
+}
+func (*errQuerier) LabelValues(string) ([]string, storage.Warnings, error) { return nil, nil, nil }
+func (*errQuerier) LabelNames() ([]string, storage.Warnings, error)        { return nil, nil, nil }
+func (*errQuerier) Close() error                                           { return nil }
+
+// errSeriesSet implements storage.SeriesSet which always returns error.
+type errSeriesSet struct {
+	err error
+}
+
+func (errSeriesSet) Next() bool         { return false }
+func (errSeriesSet) At() storage.Series { return nil }
+func (e errSeriesSet) Err() error       { return e.err }
+
+func TestQueryError(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+	errStorage := ErrStorage{errors.New("storage error")}
+	queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+		return &errQuerier{err: errStorage}, nil
+	})
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	vectorQuery, err := engine.NewInstantQuery(queryable, "foo", time.Unix(1, 0))
+	testutil.Ok(t, err)
+
+	res := vectorQuery.Exec(ctx)
+	testutil.NotOk(t, res.Err, "expected error on failed select but got none")
+	testutil.Equals(t, errStorage, res.Err)
+
+	matrixQuery, err := engine.NewInstantQuery(queryable, "foo[1m]", time.Unix(1, 0))
+	testutil.Ok(t, err)
+
+	res = matrixQuery.Exec(ctx)
+	testutil.NotOk(t, res.Err, "expected error on failed select but got none")
+	testutil.Equals(t, errStorage, res.Err)
+}
+
+// hintCheckerQuerier implements storage.Querier which checks the start and end times
+// in hints.
+type hintCheckerQuerier struct {
+	start    int64
+	end      int64
+	grouping []string
+	by       bool
+	selRange int64
+	function string
+
+	t *testing.T
+}
+
+func (q *hintCheckerQuerier) Select(_ bool, sp *storage.SelectHints, _ ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	testutil.Equals(q.t, q.start, sp.Start)
+	testutil.Equals(q.t, q.end, sp.End)
+	testutil.Equals(q.t, q.grouping, sp.Grouping)
+	testutil.Equals(q.t, q.by, sp.By)
+	testutil.Equals(q.t, q.selRange, sp.Range)
+	testutil.Equals(q.t, q.function, sp.Func)
+
+	return errSeriesSet{err: nil}, nil, nil
+}
+func (*hintCheckerQuerier) LabelValues(string) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+func (*hintCheckerQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
+func (*hintCheckerQuerier) Close() error                                    { return nil }
+
+func TestParamsSetCorrectly(t *testing.T) {
+	opts := EngineOpts{
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Second,
+	}
+
+	cases := []struct {
+		query string
+
+		// All times are in seconds.
+		start int64
+		end   int64
+
+		paramStart int64
+		paramEnd   int64
+
+		paramGrouping []string
+		paramBy       bool
+		paramRange    int64
+		paramFunc     string
+	}{{
+		query: "foo",
+		start: 10,
+
+		paramStart: 5,
+		paramEnd:   10,
+	}, {
+		query: "foo[2m]",
+		start: 200,
+
+		paramStart: 80, // 200 - 120
+		paramEnd:   200,
+		paramRange: 120000,
+	}, {
+		query: "foo[2m] offset 2m",
+		start: 300,
+
+		paramStart: 60,
+		paramEnd:   180,
+		paramRange: 120000,
+	}, {
+		query: "foo[2m:1s]",
+		start: 300,
+
+		paramStart: 175, // 300 - 120 - 5
+		paramEnd:   300,
+	}, {
+		query: "count_over_time(foo[2m:1s])",
+		start: 300,
+
+		paramStart: 175, // 300 - 120 - 5
+		paramEnd:   300,
+		paramFunc:  "count_over_time",
+	}, {
+		query: "count_over_time(foo[2m:1s] offset 10s)",
+		start: 300,
+
+		paramStart: 165, // 300 - 120 - 5 - 10
+		paramEnd:   300,
+		paramFunc:  "count_over_time",
+	}, {
+		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)",
+		start: 300,
+
+		paramStart: 155, // 300 - 120 - 5 - 10 - 10
+		paramEnd:   290,
+		paramFunc:  "count_over_time",
+	}, {
+		// Range queries now.
+		query: "foo",
+		start: 10,
+		end:   20,
+
+		paramStart: 5,
+		paramEnd:   20,
+	}, {
+		query: "rate(foo[2m])",
+		start: 200,
+		end:   500,
+
+		paramStart: 80, // 200 - 120
+		paramEnd:   500,
+		paramRange: 120000,
+		paramFunc:  "rate",
+	}, {
+		query: "rate(foo[2m] offset 2m)",
+		start: 300,
+		end:   500,
+
+		paramStart: 60,
+		paramEnd:   380,
+		paramRange: 120000,
+		paramFunc:  "rate",
+	}, {
+		query: "rate(foo[2m:1s])",
+		start: 300,
+		end:   500,
+
+		paramStart: 175, // 300 - 120 - 5
+		paramEnd:   500,
+		paramFunc:  "rate",
+	}, {
+		query: "count_over_time(foo[2m:1s])",
+		start: 300,
+		end:   500,
+
+		paramStart: 175, // 300 - 120 - 5
+		paramEnd:   500,
+		paramFunc:  "count_over_time",
+	}, {
+		query: "count_over_time(foo[2m:1s] offset 10s)",
+		start: 300,
+		end:   500,
+
+		paramStart: 165, // 300 - 120 - 5 - 10
+		paramEnd:   500,
+		paramFunc:  "count_over_time",
+	}, {
+		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)",
+		start: 300,
+		end:   500,
+
+		paramStart: 155, // 300 - 120 - 5 - 10 - 10
+		paramEnd:   490,
+		paramFunc:  "count_over_time",
+	}, {
+		query: "sum by (dim1) (foo)",
+		start: 10,
+
+		paramStart:    5,
+		paramEnd:      10,
+		paramGrouping: []string{"dim1"},
+		paramBy:       true,
+		paramFunc:     "sum",
+	}, {
+		query: "sum without (dim1) (foo)",
+		start: 10,
+
+		paramStart:    5,
+		paramEnd:      10,
+		paramGrouping: []string{"dim1"},
+		paramBy:       false,
+		paramFunc:     "sum",
+	}, {
+		query: "sum by (dim1) (avg_over_time(foo[1s]))",
+		start: 10,
+
+		paramStart:    9,
+		paramEnd:      10,
+		paramGrouping: nil,
+		paramBy:       false,
+		paramRange:    1000,
+		paramFunc:     "avg_over_time",
+	}, {
+		query: "sum by (dim1) (max by (dim2) (foo))",
+		start: 10,
+
+		paramStart:    5,
+		paramEnd:      10,
+		paramGrouping: []string{"dim2"},
+		paramBy:       true,
+		paramFunc:     "max",
+	}, {
+		query: "(max by (dim1) (foo))[5s:1s]",
+		start: 10,
+
+		paramStart:    0,
+		paramEnd:      10,
+		paramGrouping: []string{"dim1"},
+		paramBy:       true,
+		paramFunc:     "max",
+	}}
+
+	for _, tc := range cases {
+		engine := NewEngine(opts)
+		queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+			return &hintCheckerQuerier{start: tc.paramStart * 1000, end: tc.paramEnd * 1000, grouping: tc.paramGrouping, by: tc.paramBy, selRange: tc.paramRange, function: tc.paramFunc, t: t}, nil
+		})
+
+		var (
+			query Query
+			err   error
+		)
+		if tc.end == 0 {
+			query, err = engine.NewInstantQuery(queryable, tc.query, time.Unix(tc.start, 0))
+		} else {
+			query, err = engine.NewRangeQuery(queryable, tc.query, time.Unix(tc.start, 0), time.Unix(tc.end, 0), time.Second)
+		}
+		testutil.Ok(t, err)
+
+		res := query.Exec(context.Background())
+		testutil.Ok(t, res.Err)
+	}
+}
+
+func TestEngineShutdown(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	block := make(chan struct{})
+	processing := make(chan struct{})
+
+	// Shutdown engine on first handler execution. Should handler execution ever become
+	// concurrent this test has to be adjusted accordingly.
+	f := func(ctx context.Context) error {
+		processing <- struct{}{}
+		<-block
+		return contextDone(ctx, "test statement execution")
+	}
+	query1 := engine.newTestQuery(f)
+
+	// Stopping the engine must cancel the base context. While executing queries is
+	// still possible, their context is canceled from the beginning and execution should
+	// terminate immediately.
+
+	var res *Result
+	go func() {
+		res = query1.Exec(ctx)
+		processing <- struct{}{}
+	}()
+
+	<-processing
+	cancelCtx()
+	block <- struct{}{}
+	<-processing
+
+	testutil.NotOk(t, res.Err, "expected error on shutdown during query but got none")
+	testutil.Equals(t, errQueryCanceled, res.Err)
+
+	query2 := engine.newTestQuery(func(context.Context) error {
+		t.Fatalf("reached query execution unexpectedly")
+		return nil
+	})
+
+	// The second query is started after the engine shut down. It must
+	// be canceled immediately.
+	res2 := query2.Exec(ctx)
+	testutil.NotOk(t, res2.Err, "expected error on querying with canceled context but got none")
+
+	var e ErrQueryCanceled
+	// TODO: when circleci-windows moves to go 1.13:
+	// testutil.Assert(t, errors.As(res2.Err, &e), "expected cancellation error but got: %s", res2.Err)
+	testutil.Assert(t, strings.HasPrefix(res2.Err.Error(), e.Error()), "expected cancellation error but got: %s", res2.Err)
+}
+
+func TestEngineEvalStmtTimestamps(t *testing.T) {
+	test, err := NewTest(t, `
+load 10s
+  metric 1 2
+`)
+	testutil.Ok(t, err)
+	defer test.Close()
+
+	err = test.Run()
+	testutil.Ok(t, err)
+
+	cases := []struct {
+		Query       string
+		Result      parser.Value
+		Start       time.Time
+		End         time.Time
+		Interval    time.Duration
+		ShouldError bool
+	}{
+		// Instant queries.
+		{
+			Query:  "1",
+			Result: Scalar{V: 1, T: 1000},
+			Start:  time.Unix(1, 0),
+		},
+		{
+			Query: "metric",
+			Result: Vector{
+				Sample{Point: Point{V: 1, T: 1000},
+					Metric: labels.FromStrings("__name__", "metric")},
+			},
+			Start: time.Unix(1, 0),
+		},
+		{
+			Query: "metric[20s]",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 2, T: 10000}},
+				Metric: labels.FromStrings("__name__", "metric")},
+			},
+			Start: time.Unix(10, 0),
+		},
+		// Range queries.
+		{
+			Query: "1",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 1, T: 2000}},
+				Metric: labels.FromStrings()},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query: "metric",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 1, T: 2000}},
+				Metric: labels.FromStrings("__name__", "metric")},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query: "metric",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+				Metric: labels.FromStrings("__name__", "metric")},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(10, 0),
+			Interval: 5 * time.Second,
+		},
+		{
+			Query:       `count_values("wrong label!", metric)`,
+			ShouldError: true,
+		},
+	}
+
+	for _, c := range cases {
+		var err error
+		var qry Query
+		if c.Interval == 0 {
+			qry, err = test.QueryEngine().NewInstantQuery(test.Queryable(), c.Query, c.Start)
+		} else {
+			qry, err = test.QueryEngine().NewRangeQuery(test.Queryable(), c.Query, c.Start, c.End, c.Interval)
+		}
+		testutil.Ok(t, err)
+
+		res := qry.Exec(test.Context())
+		if c.ShouldError {
+			testutil.NotOk(t, res.Err, "expected error for the query %q", c.Query)
+			continue
+		}
+
+		testutil.Ok(t, res.Err)
+		testutil.Equals(t, c.Result, res.Value)
+	}
+
+}
+
+func TestMaxQuerySamples(t *testing.T) {
+	test, err := NewTest(t, `
+load 10s
+  metric 1 2
+`)
+	testutil.Ok(t, err)
+	defer test.Close()
+
+	err = test.Run()
+	testutil.Ok(t, err)
+
+	cases := []struct {
+		Query      string
+		MaxSamples int
+		Result     Result
+		Start      time.Time
+		End        time.Time
+		Interval   time.Duration
+	}{
+		// Instant queries.
+		{
+			Query:      "1",
+			MaxSamples: 1,
+			Result: Result{
+				nil,
+				Scalar{V: 1, T: 1000},
+				nil},
+			Start: time.Unix(1, 0),
+		},
+		{
+			Query:      "1",
+			MaxSamples: 0,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start: time.Unix(1, 0),
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 0,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start: time.Unix(1, 0),
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 1,
+			Result: Result{
+				nil,
+				Vector{
+					Sample{Point: Point{V: 1, T: 1000},
+						Metric: labels.FromStrings("__name__", "metric")},
+				},
+				nil,
+			},
+			Start: time.Unix(1, 0),
+		},
+		{
+			Query:      "metric[20s]",
+			MaxSamples: 2,
+			Result: Result{
+				nil,
+				Matrix{Series{
+					Points: []Point{{V: 1, T: 0}, {V: 2, T: 10000}},
+					Metric: labels.FromStrings("__name__", "metric")},
+				},
+				nil,
+			},
+			Start: time.Unix(10, 0),
+		},
+		{
+			Query:      "rate(metric[20s])",
+			MaxSamples: 3,
+			Result: Result{
+				nil,
+				Vector{
+					Sample{
+						Point:  Point{V: 0.1, T: 10000},
+						Metric: labels.Labels{},
+					},
+				},
+				nil,
+			},
+			Start: time.Unix(10, 0),
+		},
+		{
+			Query:      "metric[20s:5s]",
+			MaxSamples: 3,
+			Result: Result{
+				nil,
+				Matrix{Series{
+					Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+					Metric: labels.FromStrings("__name__", "metric")},
+				},
+				nil,
+			},
+			Start: time.Unix(10, 0),
+		},
+		{
+			Query:      "metric[20s]",
+			MaxSamples: 0,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start: time.Unix(10, 0),
+		},
+		// Range queries.
+		{
+			Query:      "1",
+			MaxSamples: 3,
+			Result: Result{
+				nil,
+				Matrix{Series{
+					Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 1, T: 2000}},
+					Metric: labels.FromStrings()},
+				},
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query:      "1",
+			MaxSamples: 0,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 3,
+			Result: Result{
+				nil,
+				Matrix{Series{
+					Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 1, T: 2000}},
+					Metric: labels.FromStrings("__name__", "metric")},
+				},
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 2,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(2, 0),
+			Interval: time.Second,
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 3,
+			Result: Result{
+				nil,
+				Matrix{Series{
+					Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+					Metric: labels.FromStrings("__name__", "metric")},
+				},
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(10, 0),
+			Interval: 5 * time.Second,
+		},
+		{
+			Query:      "metric",
+			MaxSamples: 2,
+			Result: Result{
+				ErrTooManySamples(env),
+				nil,
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(10, 0),
+			Interval: 5 * time.Second,
+		},
+	}
+
+	engine := test.QueryEngine()
+	for _, c := range cases {
+		var err error
+		var qry Query
+
+		engine.maxSamplesPerQuery = c.MaxSamples
+
+		if c.Interval == 0 {
+			qry, err = engine.NewInstantQuery(test.Queryable(), c.Query, c.Start)
+		} else {
+			qry, err = engine.NewRangeQuery(test.Queryable(), c.Query, c.Start, c.End, c.Interval)
+		}
+		testutil.Ok(t, err)
+
+		res := qry.Exec(test.Context())
+		testutil.Equals(t, c.Result.Err, res.Err)
+		testutil.Equals(t, c.Result.Value, res.Value)
+	}
+}
+
+func TestRecoverEvaluatorRuntime(t *testing.T) {
+	ev := &evaluator{logger: log.NewNopLogger()}
+
+	var err error
+	defer ev.recover(&err)
+
+	// Cause a runtime panic.
+	var a []int
+	//nolint:govet
+	a[123] = 1
+
+	if err.Error() != "unexpected error" {
+		t.Fatalf("wrong error message: %q, expected %q", err, "unexpected error")
+	}
+}
+
+func TestRecoverEvaluatorError(t *testing.T) {
+	ev := &evaluator{logger: log.NewNopLogger()}
+	var err error
+
+	e := errors.New("custom error")
+
+	defer func() {
+		if err.Error() != e.Error() {
+			t.Fatalf("wrong error message: %q, expected %q", err, e)
+		}
+	}()
+	defer ev.recover(&err)
+
+	panic(e)
+}
+
+func TestSubquerySelector(t *testing.T) {
+	tests := []struct {
+		loadString string
+		cases      []struct {
+			Query  string
+			Result Result
+			Start  time.Time
+		}
+	}{
+		{
+			loadString: `load 10s
+							metric 1 2`,
+			cases: []struct {
+				Query  string
+				Result Result
+				Start  time.Time
+			}{
+				{
+					Query: "metric[20s:10s]",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 1, T: 0}, {V: 2, T: 10000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(10, 0),
+				},
+				{
+					Query: "metric[20s:5s]",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(10, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 2s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(12, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 6s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(20, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 4s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 2, T: 15000}, {V: 2, T: 20000}, {V: 2, T: 25000}, {V: 2, T: 30000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(35, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 5s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 2, T: 10000}, {V: 2, T: 15000}, {V: 2, T: 20000}, {V: 2, T: 25000}, {V: 2, T: 30000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(35, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 6s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 2, T: 10000}, {V: 2, T: 15000}, {V: 2, T: 20000}, {V: 2, T: 25000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(35, 0),
+				},
+				{
+					Query: "metric[20s:5s] offset 7s",
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 2, T: 10000}, {V: 2, T: 15000}, {V: 2, T: 20000}, {V: 2, T: 25000}},
+							Metric: labels.FromStrings("__name__", "metric")},
+						},
+						nil,
+					},
+					Start: time.Unix(35, 0),
+				},
+			},
+		},
+		{
+			loadString: `load 10s
+							http_requests{job="api-server", instance="0", group="production"}	0+10x1000 100+30x1000
+							http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
+							http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
+							http_requests{job="api-server", instance="1", group="canary"}		0+40x2000`,
+			cases: []struct {
+				Query  string
+				Result Result
+				Start  time.Time
+			}{
+				{ // Normal selector.
+					Query: `http_requests{group=~"pro.*",instance="0"}[30s:10s]`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 9990, T: 9990000}, {V: 10000, T: 10000000}, {V: 100, T: 10010000}, {V: 130, T: 10020000}},
+							Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production")},
+						},
+						nil,
+					},
+					Start: time.Unix(10020, 0),
+				},
+				{ // Default step.
+					Query: `http_requests{group=~"pro.*",instance="0"}[5m:]`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 9840, T: 9840000}, {V: 9900, T: 9900000}, {V: 9960, T: 9960000}, {V: 130, T: 10020000}, {V: 310, T: 10080000}},
+							Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production")},
+						},
+						nil,
+					},
+					Start: time.Unix(10100, 0),
+				},
+				{ // Checking if high offset (>LookbackDelta) is being taken care of.
+					Query: `http_requests{group=~"pro.*",instance="0"}[5m:] offset 20m`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 8640, T: 8640000}, {V: 8700, T: 8700000}, {V: 8760, T: 8760000}, {V: 8820, T: 8820000}, {V: 8880, T: 8880000}},
+							Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production")},
+						},
+						nil,
+					},
+					Start: time.Unix(10100, 0),
+				},
+				{
+					Query: `rate(http_requests[1m])[15s:5s]`,
+					Result: Result{
+						nil,
+						Matrix{
+							Series{
+								Points: []Point{{V: 3, T: 7985000}, {V: 3, T: 7990000}, {V: 3, T: 7995000}, {V: 3, T: 8000000}},
+								Metric: labels.FromStrings("job", "api-server", "instance", "0", "group", "canary"),
+							},
+							Series{
+								Points: []Point{{V: 4, T: 7985000}, {V: 4, T: 7990000}, {V: 4, T: 7995000}, {V: 4, T: 8000000}},
+								Metric: labels.FromStrings("job", "api-server", "instance", "1", "group", "canary"),
+							},
+							Series{
+								Points: []Point{{V: 1, T: 7985000}, {V: 1, T: 7990000}, {V: 1, T: 7995000}, {V: 1, T: 8000000}},
+								Metric: labels.FromStrings("job", "api-server", "instance", "0", "group", "production"),
+							},
+							Series{
+								Points: []Point{{V: 2, T: 7985000}, {V: 2, T: 7990000}, {V: 2, T: 7995000}, {V: 2, T: 8000000}},
+								Metric: labels.FromStrings("job", "api-server", "instance", "1", "group", "production"),
+							},
+						},
+						nil,
+					},
+					Start: time.Unix(8000, 0),
+				},
+				{
+					Query: `sum(http_requests{group=~"pro.*"})[30s:10s]`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 270, T: 90000}, {V: 300, T: 100000}, {V: 330, T: 110000}, {V: 360, T: 120000}},
+							Metric: labels.Labels{}},
+						},
+						nil,
+					},
+					Start: time.Unix(120, 0),
+				},
+				{
+					Query: `sum(http_requests)[40s:10s]`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 800, T: 80000}, {V: 900, T: 90000}, {V: 1000, T: 100000}, {V: 1100, T: 110000}, {V: 1200, T: 120000}},
+							Metric: labels.Labels{}},
+						},
+						nil,
+					},
+					Start: time.Unix(120, 0),
+				},
+				{
+					Query: `(sum(http_requests{group=~"p.*"})+sum(http_requests{group=~"c.*"}))[20s:5s]`,
+					Result: Result{
+						nil,
+						Matrix{Series{
+							Points: []Point{{V: 1000, T: 100000}, {V: 1000, T: 105000}, {V: 1100, T: 110000}, {V: 1100, T: 115000}, {V: 1200, T: 120000}},
+							Metric: labels.Labels{}},
+						},
+						nil,
+					},
+					Start: time.Unix(120, 0),
+				},
+			},
+		},
+	}
+
+	SetDefaultEvaluationInterval(1 * time.Minute)
+	for _, tst := range tests {
+		test, err := NewTest(t, tst.loadString)
+		testutil.Ok(t, err)
+
+		defer test.Close()
+
+		err = test.Run()
+		testutil.Ok(t, err)
+
+		engine := test.QueryEngine()
+		for _, c := range tst.cases {
+			var err error
+			var qry Query
+
+			qry, err = engine.NewInstantQuery(test.Queryable(), c.Query, c.Start)
+			testutil.Ok(t, err)
+
+			res := qry.Exec(test.Context())
+			testutil.Equals(t, c.Result.Err, res.Err)
+			mat := res.Value.(Matrix)
+			sort.Sort(mat)
+			testutil.Equals(t, c.Result.Value, mat)
+		}
+	}
+}
+
+type FakeQueryLogger struct {
+	closed bool
+	logs   []interface{}
+}
+
+func NewFakeQueryLogger() *FakeQueryLogger {
+	return &FakeQueryLogger{
+		closed: false,
+		logs:   make([]interface{}, 0),
+	}
+}
+
+func (f *FakeQueryLogger) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (f *FakeQueryLogger) Log(l ...interface{}) error {
+	f.logs = append(f.logs, l...)
+	return nil
+}
+
+func TestQueryLogger_basic(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	queryExec := func() {
+		ctx, cancelCtx := context.WithCancel(context.Background())
+		defer cancelCtx()
+		query := engine.newTestQuery(func(ctx context.Context) error {
+			return contextDone(ctx, "test statement execution")
+		})
+		res := query.Exec(ctx)
+		testutil.Ok(t, res.Err)
+	}
+
+	// Query works without query log initialized.
+	queryExec()
+
+	f1 := NewFakeQueryLogger()
+	engine.SetQueryLogger(f1)
+	queryExec()
+	for i, field := range []interface{}{"params", map[string]interface{}{"query": "test statement"}} {
+		testutil.Equals(t, field, f1.logs[i])
+	}
+
+	l := len(f1.logs)
+	queryExec()
+	testutil.Equals(t, 2*l, len(f1.logs))
+
+	// Test that we close the query logger when unsetting it.
+	testutil.Assert(t, !f1.closed, "expected f1 to be open, got closed")
+	engine.SetQueryLogger(nil)
+	testutil.Assert(t, f1.closed, "expected f1 to be closed, got open")
+	queryExec()
+
+	// Test that we close the query logger when swapping.
+	f2 := NewFakeQueryLogger()
+	f3 := NewFakeQueryLogger()
+	engine.SetQueryLogger(f2)
+	testutil.Assert(t, !f2.closed, "expected f2 to be open, got closed")
+	queryExec()
+	engine.SetQueryLogger(f3)
+	testutil.Assert(t, f2.closed, "expected f2 to be closed, got open")
+	testutil.Assert(t, !f3.closed, "expected f3 to be open, got closed")
+	queryExec()
+}
+
+func TestQueryLogger_fields(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	f1 := NewFakeQueryLogger()
+	engine.SetQueryLogger(f1)
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	ctx = NewOriginContext(ctx, map[string]interface{}{"foo": "bar"})
+	defer cancelCtx()
+	query := engine.newTestQuery(func(ctx context.Context) error {
+		return contextDone(ctx, "test statement execution")
+	})
+
+	res := query.Exec(ctx)
+	testutil.Ok(t, res.Err)
+
+	expected := []string{"foo", "bar"}
+	for i, field := range expected {
+		v := f1.logs[len(f1.logs)-len(expected)+i].(string)
+		testutil.Equals(t, field, v)
+	}
+}
+
+func TestQueryLogger_error(t *testing.T) {
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	f1 := NewFakeQueryLogger()
+	engine.SetQueryLogger(f1)
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	ctx = NewOriginContext(ctx, map[string]interface{}{"foo": "bar"})
+	defer cancelCtx()
+	testErr := errors.New("failure")
+	query := engine.newTestQuery(func(ctx context.Context) error {
+		return testErr
+	})
+
+	res := query.Exec(ctx)
+	testutil.NotOk(t, res.Err, "query should have failed")
+
+	for i, field := range []interface{}{"params", map[string]interface{}{"query": "test statement"}, "error", testErr} {
+		testutil.Equals(t, f1.logs[i], field)
+	}
+}

--- a/pkg/promql/functions.go
+++ b/pkg/promql/functions.go
@@ -1,0 +1,1013 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// FunctionCall is the type of a PromQL function implementation
+//
+// vals is a list of the evaluated arguments for the function call.
+//    For range vectors it will be a Matrix with one series, instant vectors a
+//    Vector, scalars a Vector with one series whose value is the scalar
+//    value,and nil for strings.
+// args are the original arguments to the function, where you can access
+//    matrixSelectors, vectorSelectors, and StringLiterals.
+// enh.out is a pre-allocated empty vector that you may use to accumulate
+//    output before returning it. The vectors in vals should not be returned.a
+// Range vector functions need only return a vector with the right value,
+//     the metric and timestamp are not needed.
+// Instant vector functions need only return a vector with the right values and
+//     metrics, the timestamp are not needed.
+// Scalar results should be returned as the value of a sample in a Vector.
+type FunctionCall func(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector
+
+// === time() float64 ===
+func funcTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return Vector{Sample{Point: Point{
+		V: float64(enh.ts) / 1000,
+	}}}
+}
+
+// extrapolatedRate is a utility function for rate/increase/delta.
+// It calculates the rate (allowing for counter resets if isCounter is true),
+// extrapolates if the first/last sample is close to the boundary, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper, isCounter bool, isRate bool) Vector {
+	ms := args[0].(*parser.MatrixSelector)
+	vs := ms.VectorSelector.(*parser.VectorSelector)
+
+	var (
+		samples    = vals[0].(Matrix)[0]
+		rangeStart = enh.ts - durationMilliseconds(ms.Range+vs.Offset)
+		rangeEnd   = enh.ts - durationMilliseconds(vs.Offset)
+	)
+
+	// No sense in trying to compute a rate without at least two points. Drop
+	// this Vector element.
+	if len(samples.Points) < 2 {
+		return enh.out
+	}
+	var (
+		counterCorrection float64
+		lastValue         float64
+	)
+	for _, sample := range samples.Points {
+		if isCounter && sample.V < lastValue {
+			counterCorrection += lastValue
+		}
+		lastValue = sample.V
+	}
+	resultValue := lastValue - samples.Points[0].V + counterCorrection
+
+	// Duration between first/last samples and boundary of range.
+	durationToStart := float64(samples.Points[0].T-rangeStart) / 1000
+	durationToEnd := float64(rangeEnd-samples.Points[len(samples.Points)-1].T) / 1000
+
+	sampledInterval := float64(samples.Points[len(samples.Points)-1].T-samples.Points[0].T) / 1000
+	averageDurationBetweenSamples := sampledInterval / float64(len(samples.Points)-1)
+
+	if isCounter && resultValue > 0 && samples.Points[0].V >= 0 {
+		// Counters cannot be negative. If we have any slope at
+		// all (i.e. resultValue went up), we can extrapolate
+		// the zero point of the counter. If the duration to the
+		// zero point is shorter than the durationToStart, we
+		// take the zero point as the start of the series,
+		// thereby avoiding extrapolation to negative counter
+		// values.
+		durationToZero := sampledInterval * (samples.Points[0].V / resultValue)
+		if durationToZero < durationToStart {
+			durationToStart = durationToZero
+		}
+	}
+
+	// If the first/last samples are close to the boundaries of the range,
+	// extrapolate the result. This is as we expect that another sample
+	// will exist given the spacing between samples we've seen thus far,
+	// with an allowance for noise.
+	extrapolationThreshold := averageDurationBetweenSamples * 1.1
+	extrapolateToInterval := sampledInterval
+
+	if durationToStart < extrapolationThreshold {
+		extrapolateToInterval += durationToStart
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	if durationToEnd < extrapolationThreshold {
+		extrapolateToInterval += durationToEnd
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	resultValue = resultValue * (extrapolateToInterval / sampledInterval)
+	if isRate {
+		resultValue = resultValue / ms.Range.Seconds()
+	}
+
+	return append(enh.out, Sample{
+		Point: Point{V: resultValue},
+	})
+}
+
+// === delta(Matrix parser.ValueTypeMatrix) Vector ===
+func funcDelta(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, false, false)
+}
+
+// === rate(node parser.ValueTypeMatrix) Vector ===
+func funcRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, true, true)
+}
+
+// === increase(node parser.ValueTypeMatrix) Vector ===
+func funcIncrease(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, true, false)
+}
+
+// === irate(node parser.ValueTypeMatrix) Vector ===
+func funcIrate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return instantValue(vals, enh.out, true)
+}
+
+// === idelta(node model.ValMatrix) Vector ===
+func funcIdelta(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return instantValue(vals, enh.out, false)
+}
+
+func instantValue(vals []parser.Value, out Vector, isRate bool) Vector {
+	samples := vals[0].(Matrix)[0]
+	// No sense in trying to compute a rate without at least two points. Drop
+	// this Vector element.
+	if len(samples.Points) < 2 {
+		return out
+	}
+
+	lastSample := samples.Points[len(samples.Points)-1]
+	previousSample := samples.Points[len(samples.Points)-2]
+
+	var resultValue float64
+	if isRate && lastSample.V < previousSample.V {
+		// Counter reset.
+		resultValue = lastSample.V
+	} else {
+		resultValue = lastSample.V - previousSample.V
+	}
+
+	sampledInterval := lastSample.T - previousSample.T
+	if sampledInterval == 0 {
+		// Avoid dividing by 0.
+		return out
+	}
+
+	if isRate {
+		// Convert to per-second.
+		resultValue /= float64(sampledInterval) / 1000
+	}
+
+	return append(out, Sample{
+		Point: Point{V: resultValue},
+	})
+}
+
+// Calculate the trend value at the given index i in raw data d.
+// This is somewhat analogous to the slope of the trend at the given index.
+// The argument "tf" is the trend factor.
+// The argument "s0" is the computed smoothed value.
+// The argument "s1" is the computed trend factor.
+// The argument "b" is the raw input value.
+func calcTrendValue(i int, tf, s0, s1, b float64) float64 {
+	if i == 0 {
+		return b
+	}
+
+	x := tf * (s1 - s0)
+	y := (1 - tf) * b
+
+	return x + y
+}
+
+// Holt-Winters is similar to a weighted moving average, where historical data has exponentially less influence on the current data.
+// Holt-Winter also accounts for trends in data. The smoothing factor (0 < sf < 1) affects how historical data will affect the current
+// data. A lower smoothing factor increases the influence of historical data. The trend factor (0 < tf < 1) affects
+// how trends in historical data will affect the current data. A higher trend factor increases the influence.
+// of trends. Algorithm taken from https://en.wikipedia.org/wiki/Exponential_smoothing titled: "Double exponential smoothing".
+func funcHoltWinters(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+
+	// The smoothing factor argument.
+	sf := vals[1].(Vector)[0].V
+
+	// The trend factor argument.
+	tf := vals[2].(Vector)[0].V
+
+	// Sanity check the input.
+	if sf <= 0 || sf >= 1 {
+		panic(errors.Errorf("invalid smoothing factor. Expected: 0 < sf < 1, got: %f", sf))
+	}
+	if tf <= 0 || tf >= 1 {
+		panic(errors.Errorf("invalid trend factor. Expected: 0 < tf < 1, got: %f", tf))
+	}
+
+	l := len(samples.Points)
+
+	// Can't do the smoothing operation with less than two points.
+	if l < 2 {
+		return enh.out
+	}
+
+	var s0, s1, b float64
+	// Set initial values.
+	s1 = samples.Points[0].V
+	b = samples.Points[1].V - samples.Points[0].V
+
+	// Run the smoothing operation.
+	var x, y float64
+	for i := 1; i < l; i++ {
+
+		// Scale the raw value against the smoothing factor.
+		x = sf * samples.Points[i].V
+
+		// Scale the last smoothed value with the trend at this point.
+		b = calcTrendValue(i-1, tf, s0, s1, b)
+		y = (1 - sf) * (s1 + b)
+
+		s0, s1 = s1, x+y
+	}
+
+	return append(enh.out, Sample{
+		Point: Point{V: s1},
+	})
+}
+
+// === sort(node parser.ValueTypeVector) Vector ===
+func funcSort(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	// NaN should sort to the bottom, so take descending sort with NaN first and
+	// reverse it.
+	byValueSorter := vectorByReverseValueHeap(vals[0].(Vector))
+	sort.Sort(sort.Reverse(byValueSorter))
+	return Vector(byValueSorter)
+}
+
+// === sortDesc(node parser.ValueTypeVector) Vector ===
+func funcSortDesc(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	// NaN should sort to the bottom, so take ascending sort with NaN first and
+	// reverse it.
+	byValueSorter := vectorByValueHeap(vals[0].(Vector))
+	sort.Sort(sort.Reverse(byValueSorter))
+	return Vector(byValueSorter)
+}
+
+// === clamp_max(Vector parser.ValueTypeVector, max Scalar) Vector ===
+func funcClampMax(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	max := vals[1].(Vector)[0].Point.V
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: math.Min(max, el.V)},
+		})
+	}
+	return enh.out
+}
+
+// === clamp_min(Vector parser.ValueTypeVector, min Scalar) Vector ===
+func funcClampMin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	min := vals[1].(Vector)[0].Point.V
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: math.Max(min, el.V)},
+		})
+	}
+	return enh.out
+}
+
+// === round(Vector parser.ValueTypeVector, toNearest=1 Scalar) Vector ===
+func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	// round returns a number rounded to toNearest.
+	// Ties are solved by rounding up.
+	toNearest := float64(1)
+	if len(args) >= 2 {
+		toNearest = vals[1].(Vector)[0].Point.V
+	}
+	// Invert as it seems to cause fewer floating point accuracy issues.
+	toNearestInverse := 1.0 / toNearest
+
+	for _, el := range vec {
+		v := math.Floor(el.V*toNearestInverse+0.5) / toNearestInverse
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: v},
+		})
+	}
+	return enh.out
+}
+
+// === Scalar(node parser.ValueTypeVector) Scalar ===
+func funcScalar(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	v := vals[0].(Vector)
+	if len(v) != 1 {
+		return append(enh.out, Sample{
+			Point: Point{V: math.NaN()},
+		})
+	}
+	return append(enh.out, Sample{
+		Point: Point{V: v[0].V},
+	})
+}
+
+func aggrOverTime(vals []parser.Value, enh *EvalNodeHelper, aggrFn func([]Point) float64) Vector {
+	el := vals[0].(Matrix)[0]
+
+	return append(enh.out, Sample{
+		Point: Point{V: aggrFn(el.Points)},
+	})
+}
+
+// === avg_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var mean, count float64
+		for _, v := range values {
+			count++
+			mean += (v.V - mean) / count
+		}
+		return mean
+	})
+}
+
+// === count_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcCountOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		return float64(len(values))
+	})
+}
+
+// === floor(Vector parser.ValueTypeVector) Vector ===
+// === max_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcMaxOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		max := values[0].V
+		for _, v := range values {
+			if v.V > max || math.IsNaN(max) {
+				max = v.V
+			}
+		}
+		return max
+	})
+}
+
+// === min_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcMinOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		min := values[0].V
+		for _, v := range values {
+			if v.V < min || math.IsNaN(min) {
+				min = v.V
+			}
+		}
+		return min
+	})
+}
+
+// === sum_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcSumOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var sum float64
+		for _, v := range values {
+			sum += v.V
+		}
+		return sum
+	})
+}
+
+// === quantile_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	q := vals[0].(Vector)[0].V
+	el := vals[1].(Matrix)[0]
+
+	values := make(vectorByValueHeap, 0, len(el.Points))
+	for _, v := range el.Points {
+		values = append(values, Sample{Point: Point{V: v.V}})
+	}
+	return append(enh.out, Sample{
+		Point: Point{V: quantile(q, values)},
+	})
+}
+
+// === stddev_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcStddevOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var aux, count, mean float64
+		for _, v := range values {
+			count++
+			delta := v.V - mean
+			mean += delta / count
+			aux += delta * (v.V - mean)
+		}
+		return math.Sqrt(aux / count)
+	})
+}
+
+// === stdvar_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcStdvarOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var aux, count, mean float64
+		for _, v := range values {
+			count++
+			delta := v.V - mean
+			mean += delta / count
+			aux += delta * (v.V - mean)
+		}
+		return aux / count
+	})
+}
+
+// === absent(Vector parser.ValueTypeVector) Vector ===
+func funcAbsent(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	if len(vals[0].(Vector)) > 0 {
+		return enh.out
+	}
+	return append(enh.out,
+		Sample{
+			Metric: createLabelsForAbsentFunction(args[0]),
+			Point:  Point{V: 1},
+		})
+}
+
+// === absent_over_time(Vector parser.ValueTypeMatrix) Vector ===
+// As this function has a matrix as argument, it does not get all the Series.
+// This function will return 1 if the matrix has at least one element.
+// Due to engine optimization, this function is only called when this condition is true.
+// Then, the engine post-processes the results to get the expected output.
+func funcAbsentOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return append(enh.out,
+		Sample{
+			Point: Point{V: 1},
+		})
+}
+
+func simpleFunc(vals []parser.Value, enh *EvalNodeHelper, f func(float64) float64) Vector {
+	for _, el := range vals[0].(Vector) {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: f(el.V)},
+		})
+	}
+	return enh.out
+}
+
+// === abs(Vector parser.ValueTypeVector) Vector ===
+func funcAbs(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Abs)
+}
+
+// === ceil(Vector parser.ValueTypeVector) Vector ===
+func funcCeil(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Ceil)
+}
+
+// === floor(Vector parser.ValueTypeVector) Vector ===
+func funcFloor(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Floor)
+}
+
+// === exp(Vector parser.ValueTypeVector) Vector ===
+func funcExp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Exp)
+}
+
+// === sqrt(Vector VectorNode) Vector ===
+func funcSqrt(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Sqrt)
+}
+
+// === ln(Vector parser.ValueTypeVector) Vector ===
+func funcLn(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log)
+}
+
+// === log2(Vector parser.ValueTypeVector) Vector ===
+func funcLog2(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log2)
+}
+
+// === log10(Vector parser.ValueTypeVector) Vector ===
+func funcLog10(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log10)
+}
+
+// === timestamp(Vector parser.ValueTypeVector) Vector ===
+func funcTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: float64(el.T) / 1000},
+		})
+	}
+	return enh.out
+}
+
+// linearRegression performs a least-square linear regression analysis on the
+// provided SamplePairs. It returns the slope, and the intercept value at the
+// provided time.
+func linearRegression(samples []Point, interceptTime int64) (slope, intercept float64) {
+	var (
+		n            float64
+		sumX, sumY   float64
+		sumXY, sumX2 float64
+	)
+	for _, sample := range samples {
+		x := float64(sample.T-interceptTime) / 1e3
+		n += 1.0
+		sumY += sample.V
+		sumX += x
+		sumXY += x * sample.V
+		sumX2 += x * x
+	}
+	covXY := sumXY - sumX*sumY/n
+	varX := sumX2 - sumX*sumX/n
+
+	slope = covXY / varX
+	intercept = sumY/n - slope*sumX/n
+	return slope, intercept
+}
+
+// === deriv(node parser.ValueTypeMatrix) Vector ===
+func funcDeriv(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+
+	// No sense in trying to compute a derivative without at least two points.
+	// Drop this Vector element.
+	if len(samples.Points) < 2 {
+		return enh.out
+	}
+
+	// We pass in an arbitrary timestamp that is near the values in use
+	// to avoid floating point accuracy issues, see
+	// https://github.com/prometheus/prometheus/issues/2674
+	slope, _ := linearRegression(samples.Points, samples.Points[0].T)
+	return append(enh.out, Sample{
+		Point: Point{V: slope},
+	})
+}
+
+// === predict_linear(node parser.ValueTypeMatrix, k parser.ValueTypeScalar) Vector ===
+func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+	duration := vals[1].(Vector)[0].V
+
+	// No sense in trying to predict anything without at least two points.
+	// Drop this Vector element.
+	if len(samples.Points) < 2 {
+		return enh.out
+	}
+	slope, intercept := linearRegression(samples.Points, enh.ts)
+
+	return append(enh.out, Sample{
+		Point: Point{V: slope*duration + intercept},
+	})
+}
+
+// === histogram_quantile(k parser.ValueTypeScalar, Vector parser.ValueTypeVector) Vector ===
+func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	q := vals[0].(Vector)[0].V
+	inVec := vals[1].(Vector)
+	sigf := enh.signatureFunc(false, excludedLabels...)
+
+	if enh.signatureToMetricWithBuckets == nil {
+		enh.signatureToMetricWithBuckets = map[uint64]*metricWithBuckets{}
+	} else {
+		for _, v := range enh.signatureToMetricWithBuckets {
+			v.buckets = v.buckets[:0]
+		}
+	}
+	for _, el := range inVec {
+		upperBound, err := strconv.ParseFloat(
+			el.Metric.Get(model.BucketLabel), 64,
+		)
+		if err != nil {
+			// Oops, no bucket label or malformed label value. Skip.
+			// TODO(beorn7): Issue a warning somehow.
+			continue
+		}
+		hash := sigf(el.Metric)
+
+		mb, ok := enh.signatureToMetricWithBuckets[hash]
+		if !ok {
+			el.Metric = labels.NewBuilder(el.Metric).
+				Del(labels.BucketLabel, labels.MetricName).
+				Labels()
+
+			mb = &metricWithBuckets{el.Metric, nil}
+			enh.signatureToMetricWithBuckets[hash] = mb
+		}
+		mb.buckets = append(mb.buckets, bucket{upperBound, el.V})
+	}
+
+	for _, mb := range enh.signatureToMetricWithBuckets {
+		if len(mb.buckets) > 0 {
+			enh.out = append(enh.out, Sample{
+				Metric: mb.metric,
+				Point:  Point{V: bucketQuantile(q, mb.buckets)},
+			})
+		}
+	}
+
+	return enh.out
+}
+
+// === resets(Matrix parser.ValueTypeMatrix) Vector ===
+func funcResets(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+
+	resets := 0
+	prev := samples.Points[0].V
+	for _, sample := range samples.Points[1:] {
+		current := sample.V
+		if current < prev {
+			resets++
+		}
+		prev = current
+	}
+
+	return append(enh.out, Sample{
+		Point: Point{V: float64(resets)},
+	})
+}
+
+// === changes(Matrix parser.ValueTypeMatrix) Vector ===
+func funcChanges(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+
+	changes := 0
+	prev := samples.Points[0].V
+	for _, sample := range samples.Points[1:] {
+		current := sample.V
+		if current != prev && !(math.IsNaN(current) && math.IsNaN(prev)) {
+			changes++
+		}
+		prev = current
+	}
+
+	return append(enh.out, Sample{
+		Point: Point{V: float64(changes)},
+	})
+}
+
+// === label_replace(Vector parser.ValueTypeVector, dst_label, replacement, src_labelname, regex parser.ValueTypeString) Vector ===
+func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	var (
+		vector   = vals[0].(Vector)
+		dst      = args[1].(*parser.StringLiteral).Val
+		repl     = args[2].(*parser.StringLiteral).Val
+		src      = args[3].(*parser.StringLiteral).Val
+		regexStr = args[4].(*parser.StringLiteral).Val
+	)
+
+	if enh.regex == nil {
+		var err error
+		enh.regex, err = regexp.Compile("^(?:" + regexStr + ")$")
+		if err != nil {
+			panic(errors.Errorf("invalid regular expression in label_replace(): %s", regexStr))
+		}
+		if !model.LabelNameRE.MatchString(dst) {
+			panic(errors.Errorf("invalid destination label name in label_replace(): %s", dst))
+		}
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+
+	for _, el := range vector {
+		h := el.Metric.Hash()
+		var outMetric labels.Labels
+		if l, ok := enh.dmn[h]; ok {
+			outMetric = l
+		} else {
+			srcVal := el.Metric.Get(src)
+			indexes := enh.regex.FindStringSubmatchIndex(srcVal)
+			if indexes == nil {
+				// If there is no match, no replacement should take place.
+				outMetric = el.Metric
+				enh.dmn[h] = outMetric
+			} else {
+				res := enh.regex.ExpandString([]byte{}, repl, srcVal, indexes)
+
+				lb := labels.NewBuilder(el.Metric).Del(dst)
+				if len(res) > 0 {
+					lb.Set(dst, string(res))
+				}
+				outMetric = lb.Labels()
+				enh.dmn[h] = outMetric
+			}
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: outMetric,
+			Point:  Point{V: el.Point.V},
+		})
+	}
+	return enh.out
+}
+
+// === Vector(s Scalar) Vector ===
+func funcVector(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return append(enh.out,
+		Sample{
+			Metric: labels.Labels{},
+			Point:  Point{V: vals[0].(Vector)[0].V},
+		})
+}
+
+// === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) Vector ===
+func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	var (
+		vector    = vals[0].(Vector)
+		dst       = args[1].(*parser.StringLiteral).Val
+		sep       = args[2].(*parser.StringLiteral).Val
+		srcLabels = make([]string, len(args)-3)
+	)
+
+	if enh.dmn == nil {
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+
+	for i := 3; i < len(args); i++ {
+		src := args[i].(*parser.StringLiteral).Val
+		if !model.LabelName(src).IsValid() {
+			panic(errors.Errorf("invalid source label name in label_join(): %s", src))
+		}
+		srcLabels[i-3] = src
+	}
+
+	if !model.LabelName(dst).IsValid() {
+		panic(errors.Errorf("invalid destination label name in label_join(): %s", dst))
+	}
+
+	srcVals := make([]string, len(srcLabels))
+	for _, el := range vector {
+		h := el.Metric.Hash()
+		var outMetric labels.Labels
+		if l, ok := enh.dmn[h]; ok {
+			outMetric = l
+		} else {
+
+			for i, src := range srcLabels {
+				srcVals[i] = el.Metric.Get(src)
+			}
+
+			lb := labels.NewBuilder(el.Metric)
+
+			strval := strings.Join(srcVals, sep)
+			if strval == "" {
+				lb.Del(dst)
+			} else {
+				lb.Set(dst, strval)
+			}
+
+			outMetric = lb.Labels()
+			enh.dmn[h] = outMetric
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: outMetric,
+			Point:  Point{V: el.Point.V},
+		})
+	}
+	return enh.out
+}
+
+// Common code for date related functions.
+func dateWrapper(vals []parser.Value, enh *EvalNodeHelper, f func(time.Time) float64) Vector {
+	if len(vals) == 0 {
+		return append(enh.out,
+			Sample{
+				Metric: labels.Labels{},
+				Point:  Point{V: f(time.Unix(enh.ts/1000, 0).UTC())},
+			})
+	}
+
+	for _, el := range vals[0].(Vector) {
+		t := time.Unix(int64(el.V), 0).UTC()
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: f(t)},
+		})
+	}
+	return enh.out
+}
+
+// === days_in_month(v Vector) Scalar ===
+func funcDaysInMonth(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(32 - time.Date(t.Year(), t.Month(), 32, 0, 0, 0, 0, time.UTC).Day())
+	})
+}
+
+// === day_of_month(v Vector) Scalar ===
+func funcDayOfMonth(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Day())
+	})
+}
+
+// === day_of_week(v Vector) Scalar ===
+func funcDayOfWeek(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Weekday())
+	})
+}
+
+// === hour(v Vector) Scalar ===
+func funcHour(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Hour())
+	})
+}
+
+// === minute(v Vector) Scalar ===
+func funcMinute(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Minute())
+	})
+}
+
+// === month(v Vector) Scalar ===
+func funcMonth(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Month())
+	})
+}
+
+// === year(v Vector) Scalar ===
+func funcYear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Year())
+	})
+}
+
+// FunctionCalls is a list of all functions supported by PromQL, including their types.
+var FunctionCalls = map[string]FunctionCall{
+	"abs":                funcAbs,
+	"absent":             funcAbsent,
+	"absent_over_time":   funcAbsentOverTime,
+	"avg_over_time":      funcAvgOverTime,
+	"ceil":               funcCeil,
+	"changes":            funcChanges,
+	"clamp_max":          funcClampMax,
+	"clamp_min":          funcClampMin,
+	"count_over_time":    funcCountOverTime,
+	"days_in_month":      funcDaysInMonth,
+	"day_of_month":       funcDayOfMonth,
+	"day_of_week":        funcDayOfWeek,
+	"delta":              funcDelta,
+	"deriv":              funcDeriv,
+	"exp":                funcExp,
+	"floor":              funcFloor,
+	"histogram_quantile": funcHistogramQuantile,
+	"holt_winters":       funcHoltWinters,
+	"hour":               funcHour,
+	"idelta":             funcIdelta,
+	"increase":           funcIncrease,
+	"irate":              funcIrate,
+	"label_replace":      funcLabelReplace,
+	"label_join":         funcLabelJoin,
+	"ln":                 funcLn,
+	"log10":              funcLog10,
+	"log2":               funcLog2,
+	"max_over_time":      funcMaxOverTime,
+	"min_over_time":      funcMinOverTime,
+	"minute":             funcMinute,
+	"month":              funcMonth,
+	"predict_linear":     funcPredictLinear,
+	"quantile_over_time": funcQuantileOverTime,
+	"rate":               funcRate,
+	"resets":             funcResets,
+	"round":              funcRound,
+	"scalar":             funcScalar,
+	"sort":               funcSort,
+	"sort_desc":          funcSortDesc,
+	"sqrt":               funcSqrt,
+	"stddev_over_time":   funcStddevOverTime,
+	"stdvar_over_time":   funcStdvarOverTime,
+	"sum_over_time":      funcSumOverTime,
+	"time":               funcTime,
+	"timestamp":          funcTimestamp,
+	"vector":             funcVector,
+	"year":               funcYear,
+}
+
+type vectorByValueHeap Vector
+
+func (s vectorByValueHeap) Len() int {
+	return len(s)
+}
+
+func (s vectorByValueHeap) Less(i, j int) bool {
+	if math.IsNaN(s[i].V) {
+		return true
+	}
+	return s[i].V < s[j].V
+}
+
+func (s vectorByValueHeap) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s *vectorByValueHeap) Push(x interface{}) {
+	*s = append(*s, *(x.(*Sample)))
+}
+
+func (s *vectorByValueHeap) Pop() interface{} {
+	old := *s
+	n := len(old)
+	el := old[n-1]
+	*s = old[0 : n-1]
+	return el
+}
+
+type vectorByReverseValueHeap Vector
+
+func (s vectorByReverseValueHeap) Len() int {
+	return len(s)
+}
+
+func (s vectorByReverseValueHeap) Less(i, j int) bool {
+	if math.IsNaN(s[i].V) {
+		return true
+	}
+	return s[i].V > s[j].V
+}
+
+func (s vectorByReverseValueHeap) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s *vectorByReverseValueHeap) Push(x interface{}) {
+	*s = append(*s, *(x.(*Sample)))
+}
+
+func (s *vectorByReverseValueHeap) Pop() interface{} {
+	old := *s
+	n := len(old)
+	el := old[n-1]
+	*s = old[0 : n-1]
+	return el
+}
+
+// createLabelsForAbsentFunction returns the labels that are uniquely and exactly matched
+// in a given expression. It is used in the absent functions.
+func createLabelsForAbsentFunction(expr parser.Expr) labels.Labels {
+	m := labels.Labels{}
+
+	var lm []*labels.Matcher
+	switch n := expr.(type) {
+	case *parser.VectorSelector:
+		lm = n.LabelMatchers
+	case *parser.MatrixSelector:
+		lm = n.VectorSelector.(*parser.VectorSelector).LabelMatchers
+	default:
+		return m
+	}
+
+	empty := []string{}
+	for _, ma := range lm {
+		if ma.Name == labels.MetricName {
+			continue
+		}
+		if ma.Type == labels.MatchEqual && !m.Has(ma.Name) {
+			m = labels.NewBuilder(m).Set(ma.Name, ma.Value).Labels()
+		} else {
+			empty = append(empty, ma.Name)
+		}
+	}
+
+	for _, v := range empty {
+		m = labels.NewBuilder(m).Del(v).Labels()
+	}
+	return m
+}

--- a/pkg/promql/functions_test.go
+++ b/pkg/promql/functions_test.go
@@ -1,0 +1,73 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestDeriv(t *testing.T) {
+	// https://github.com/prometheus/prometheus/issues/2674#issuecomment-315439393
+	// This requires more precision than the usual test system offers,
+	// so we test it by hand.
+	storage := teststorage.New(t)
+	defer storage.Close()
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10000,
+		Timeout:    10 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	a := storage.Appender()
+
+	metric := labels.FromStrings("__name__", "foo")
+	a.Add(metric, 1493712816939, 1.0)
+	a.Add(metric, 1493712846939, 1.0)
+
+	testutil.Ok(t, a.Commit())
+
+	query, err := engine.NewInstantQuery(storage, "deriv(foo[30m])", timestamp.Time(1493712846939))
+	testutil.Ok(t, err)
+
+	result := query.Exec(context.Background())
+	testutil.Ok(t, result.Err)
+
+	vec, _ := result.Vector()
+	testutil.Assert(t, len(vec) == 1, "Expected 1 result, got %d", len(vec))
+	testutil.Assert(t, vec[0].V == 0.0, "Expected 0.0 as value, got %f", vec[0].V)
+}
+
+func TestFunctionList(t *testing.T) {
+	// Test that Functions and parser.Functions list the same functions.
+	for i := range FunctionCalls {
+		_, ok := parser.Functions[i]
+		testutil.Assert(t, ok, fmt.Sprintf("function %s exists in promql package, but not in parser package", i))
+	}
+
+	for i := range parser.Functions {
+		_, ok := FunctionCalls[i]
+		testutil.Assert(t, ok, (fmt.Sprintf("function %s exists in parser package, but not in promql package", i)))
+	}
+}

--- a/pkg/promql/functions_test.go
+++ b/pkg/promql/functions_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -30,7 +29,7 @@ func TestDeriv(t *testing.T) {
 	// https://github.com/prometheus/prometheus/issues/2674#issuecomment-315439393
 	// This requires more precision than the usual test system offers,
 	// so we test it by hand.
-	storage := teststorage.New(t)
+	storage := NewTestStorage(t)
 	defer storage.Close()
 	opts := EngineOpts{
 		Logger:     nil,

--- a/pkg/promql/fuzz.go
+++ b/pkg/promql/fuzz.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Only build when go-fuzz is in use
+// +build gofuzz
+
+package promql
+
+import (
+	"io"
+
+	"github.com/prometheus/prometheus/pkg/textparse"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// PromQL parser fuzzing instrumentation for use with
+// https://github.com/dvyukov/go-fuzz.
+//
+// Fuzz each parser by building appropriately instrumented parser, ex.
+// FuzzParseMetric and execute it with it's
+//
+//     go-fuzz-build -func FuzzParseMetric -o FuzzParseMetric.zip github.com/prometheus/prometheus/promql
+//
+// And then run the tests with the appropriate inputs
+//
+//     go-fuzz -bin FuzzParseMetric.zip -workdir fuzz-data/ParseMetric
+//
+// Further input samples should go in the folders fuzz-data/ParseMetric/corpus.
+//
+// Repeat for FuzzParseOpenMetric, FuzzParseMetricSelector and FuzzParseExpr.
+
+// Tuning which value is returned from Fuzz*-functions has a strong influence
+// on how quick the fuzzer converges on "interesting" cases. At least try
+// switching between fuzzMeh (= included in corpus, but not a priority) and
+// fuzzDiscard (=don't use this input for re-building later inputs) when
+// experimenting.
+const (
+	fuzzInteresting = 1
+	fuzzMeh         = 0
+	fuzzDiscard     = -1
+)
+
+func fuzzParseMetricWithContentType(in []byte, contentType string) int {
+	p := textparse.New(in, contentType)
+	var err error
+	for {
+		_, err = p.Next()
+		if err != nil {
+			break
+		}
+	}
+	if err == io.EOF {
+		err = nil
+	}
+
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}
+
+// Fuzz the metric parser.
+//
+// Note that this is not the parser for the text-based exposition-format; that
+// lives in github.com/prometheus/client_golang/text.
+func FuzzParseMetric(in []byte) int {
+	return fuzzParseMetricWithContentType(in, "")
+}
+
+func FuzzParseOpenMetric(in []byte) int {
+	return fuzzParseMetricWithContentType(in, "application/openmetrics-text")
+}
+
+// Fuzz the metric selector parser.
+func FuzzParseMetricSelector(in []byte) int {
+	_, err := parser.ParseMetricSelector(string(in))
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}
+
+// Fuzz the expression parser.
+func FuzzParseExpr(in []byte) int {
+	_, err := parser.ParseExpr(string(in))
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}

--- a/pkg/promql/promql_test.go
+++ b/pkg/promql/promql_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestEvaluations(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.test")
+	testutil.Ok(t, err)
+
+	for _, fn := range files {
+		test, err := newTestFromFile(t, fn)
+		testutil.Ok(t, err)
+
+		testutil.Ok(t, test.Run())
+
+		test.Close()
+	}
+}

--- a/pkg/promql/quantile.go
+++ b/pkg/promql/quantile.go
@@ -1,0 +1,204 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Helpers to calculate quantiles.
+
+// excludedLabels are the labels to exclude from signature calculation for
+// quantiles.
+var excludedLabels = []string{
+	labels.MetricName,
+	labels.BucketLabel,
+}
+
+type bucket struct {
+	upperBound float64
+	count      float64
+}
+
+// buckets implements sort.Interface.
+type buckets []bucket
+
+func (b buckets) Len() int           { return len(b) }
+func (b buckets) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b buckets) Less(i, j int) bool { return b[i].upperBound < b[j].upperBound }
+
+type metricWithBuckets struct {
+	metric  labels.Labels
+	buckets buckets
+}
+
+// bucketQuantile calculates the quantile 'q' based on the given buckets. The
+// buckets will be sorted by upperBound by this function (i.e. no sorting
+// needed before calling this function). The quantile value is interpolated
+// assuming a linear distribution within a bucket. However, if the quantile
+// falls into the highest bucket, the upper bound of the 2nd highest bucket is
+// returned. A natural lower bound of 0 is assumed if the upper bound of the
+// lowest bucket is greater 0. In that case, interpolation in the lowest bucket
+// happens linearly between 0 and the upper bound of the lowest bucket.
+// However, if the lowest bucket has an upper bound less or equal 0, this upper
+// bound is returned if the quantile falls into the lowest bucket.
+//
+// There are a number of special cases (once we have a way to report errors
+// happening during evaluations of AST functions, we should report those
+// explicitly):
+//
+// If 'buckets' has fewer than 2 elements, NaN is returned.
+//
+// If the highest bucket is not +Inf, NaN is returned.
+//
+// If q<0, -Inf is returned.
+//
+// If q>1, +Inf is returned.
+func bucketQuantile(q float64, buckets buckets) float64 {
+	if q < 0 {
+		return math.Inf(-1)
+	}
+	if q > 1 {
+		return math.Inf(+1)
+	}
+	sort.Sort(buckets)
+	if !math.IsInf(buckets[len(buckets)-1].upperBound, +1) {
+		return math.NaN()
+	}
+
+	buckets = coalesceBuckets(buckets)
+	ensureMonotonic(buckets)
+
+	if len(buckets) < 2 {
+		return math.NaN()
+	}
+
+	rank := q * buckets[len(buckets)-1].count
+	b := sort.Search(len(buckets)-1, func(i int) bool { return buckets[i].count >= rank })
+
+	if b == len(buckets)-1 {
+		return buckets[len(buckets)-2].upperBound
+	}
+	if b == 0 && buckets[0].upperBound <= 0 {
+		return buckets[0].upperBound
+	}
+	var (
+		bucketStart float64
+		bucketEnd   = buckets[b].upperBound
+		count       = buckets[b].count
+	)
+	if b > 0 {
+		bucketStart = buckets[b-1].upperBound
+		count -= buckets[b-1].count
+		rank -= buckets[b-1].count
+	}
+	return bucketStart + (bucketEnd-bucketStart)*(rank/count)
+}
+
+// coalesceBuckets merges buckets with the same upper bound.
+//
+// The input buckets must be sorted.
+func coalesceBuckets(buckets buckets) buckets {
+	last := buckets[0]
+	i := 0
+	for _, b := range buckets[1:] {
+		if b.upperBound == last.upperBound {
+			last.count += b.count
+		} else {
+			buckets[i] = last
+			last = b
+			i++
+		}
+	}
+	buckets[i] = last
+	return buckets[:i+1]
+}
+
+// The assumption that bucket counts increase monotonically with increasing
+// upperBound may be violated during:
+//
+//   * Recording rule evaluation of histogram_quantile, especially when rate()
+//      has been applied to the underlying bucket timeseries.
+//   * Evaluation of histogram_quantile computed over federated bucket
+//      timeseries, especially when rate() has been applied.
+//
+// This is because scraped data is not made available to rule evaluation or
+// federation atomically, so some buckets are computed with data from the
+// most recent scrapes, but the other buckets are missing data from the most
+// recent scrape.
+//
+// Monotonicity is usually guaranteed because if a bucket with upper bound
+// u1 has count c1, then any bucket with a higher upper bound u > u1 must
+// have counted all c1 observations and perhaps more, so that c  >= c1.
+//
+// Randomly interspersed partial sampling breaks that guarantee, and rate()
+// exacerbates it. Specifically, suppose bucket le=1000 has a count of 10 from
+// 4 samples but the bucket with le=2000 has a count of 7 from 3 samples. The
+// monotonicity is broken. It is exacerbated by rate() because under normal
+// operation, cumulative counting of buckets will cause the bucket counts to
+// diverge such that small differences from missing samples are not a problem.
+// rate() removes this divergence.)
+//
+// bucketQuantile depends on that monotonicity to do a binary search for the
+// bucket with the φ-quantile count, so breaking the monotonicity
+// guarantee causes bucketQuantile() to return undefined (nonsense) results.
+//
+// As a somewhat hacky solution until ingestion is atomic per scrape, we
+// calculate the "envelope" of the histogram buckets, essentially removing
+// any decreases in the count between successive buckets.
+
+func ensureMonotonic(buckets buckets) {
+	max := buckets[0].count
+	for i := range buckets[1:] {
+		switch {
+		case buckets[i].count > max:
+			max = buckets[i].count
+		case buckets[i].count < max:
+			buckets[i].count = max
+		}
+	}
+}
+
+// quantile calculates the given quantile of a vector of samples.
+//
+// The Vector will be sorted.
+// If 'values' has zero elements, NaN is returned.
+// If q<0, -Inf is returned.
+// If q>1, +Inf is returned.
+func quantile(q float64, values vectorByValueHeap) float64 {
+	if len(values) == 0 {
+		return math.NaN()
+	}
+	if q < 0 {
+		return math.Inf(-1)
+	}
+	if q > 1 {
+		return math.Inf(+1)
+	}
+	sort.Sort(values)
+
+	n := float64(len(values))
+	// When the quantile lies between two samples,
+	// we use a weighted average of the two samples.
+	rank := q * (n - 1)
+
+	lowerIndex := math.Max(0, math.Floor(rank))
+	upperIndex := math.Min(n-1, lowerIndex+1)
+
+	weight := rank - math.Floor(rank)
+	return values[int(lowerIndex)].V*(1-weight) + values[int(upperIndex)].V*weight
+}

--- a/pkg/promql/query_logger.go
+++ b/pkg/promql/query_logger.go
@@ -1,0 +1,197 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+type ActiveQueryTracker struct {
+	mmapedFile    []byte
+	getNextIndex  chan int
+	logger        log.Logger
+	maxConcurrent int
+}
+
+type Entry struct {
+	Query     string `json:"query"`
+	Timestamp int64  `json:"timestamp_sec"`
+}
+
+const (
+	entrySize int = 1000
+)
+
+func parseBrokenJSON(brokenJSON []byte) (bool, string) {
+	queries := strings.ReplaceAll(string(brokenJSON), "\x00", "")
+	if len(queries) > 0 {
+		queries = queries[:len(queries)-1] + "]"
+	}
+
+	// Conditional because of implementation detail: len() = 1 implies file consisted of a single char: '['.
+	if len(queries) <= 1 {
+		return false, "[]"
+	}
+
+	return true, queries
+}
+
+func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
+	if _, err := os.Stat(filename); err == nil {
+		fd, err := os.Open(filename)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to open query log file", "err", err)
+			return
+		}
+
+		brokenJSON := make([]byte, filesize)
+		_, err = fd.Read(brokenJSON)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to read query log file", "err", err)
+			return
+		}
+
+		queriesExist, queries := parseBrokenJSON(brokenJSON)
+		if !queriesExist {
+			return
+		}
+		level.Info(logger).Log("msg", "These queries didn't finish in prometheus' last run:", "queries", queries)
+	}
+}
+
+func getMMapedFile(filename string, filesize int, logger log.Logger) ([]byte, error) {
+
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0666)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error opening query log file", "file", filename, "err", err)
+		return nil, err
+	}
+
+	err = file.Truncate(int64(filesize))
+	if err != nil {
+		level.Error(logger).Log("msg", "Error setting filesize.", "filesize", filesize, "err", err)
+		return nil, err
+	}
+
+	fileAsBytes, err := mmap.Map(file, mmap.RDWR, 0)
+	if err != nil {
+		level.Error(logger).Log("msg", "Failed to mmap", "file", filename, "Attempted size", filesize, "err", err)
+		return nil, err
+	}
+
+	return fileAsBytes, err
+}
+
+func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger log.Logger) *ActiveQueryTracker {
+	err := os.MkdirAll(localStoragePath, 0777)
+	if err != nil {
+		level.Error(logger).Log("msg", "Failed to create directory for logging active queries")
+	}
+
+	filename, filesize := filepath.Join(localStoragePath, "queries.active"), 1+maxConcurrent*entrySize
+	logUnfinishedQueries(filename, filesize, logger)
+
+	fileAsBytes, err := getMMapedFile(filename, filesize, logger)
+	if err != nil {
+		panic("Unable to create mmap-ed active query log")
+	}
+
+	copy(fileAsBytes, "[")
+	activeQueryTracker := ActiveQueryTracker{
+		mmapedFile:    fileAsBytes,
+		getNextIndex:  make(chan int, maxConcurrent),
+		logger:        logger,
+		maxConcurrent: maxConcurrent,
+	}
+
+	activeQueryTracker.generateIndices(maxConcurrent)
+
+	return &activeQueryTracker
+}
+
+func trimStringByBytes(str string, size int) string {
+	bytesStr := []byte(str)
+
+	trimIndex := len(bytesStr)
+	if size < len(bytesStr) {
+		for !utf8.RuneStart(bytesStr[size]) {
+			size--
+		}
+		trimIndex = size
+	}
+
+	return string(bytesStr[:trimIndex])
+}
+
+func _newJSONEntry(query string, timestamp int64, logger log.Logger) []byte {
+	entry := Entry{query, timestamp}
+	jsonEntry, err := json.Marshal(entry)
+
+	if err != nil {
+		level.Error(logger).Log("msg", "Cannot create json of query", "query", query)
+		return []byte{}
+	}
+
+	return jsonEntry
+}
+
+func newJSONEntry(query string, logger log.Logger) []byte {
+	timestamp := time.Now().Unix()
+	minEntryJSON := _newJSONEntry("", timestamp, logger)
+
+	query = trimStringByBytes(query, entrySize-(len(minEntryJSON)+1))
+	jsonEntry := _newJSONEntry(query, timestamp, logger)
+
+	return jsonEntry
+}
+
+func (tracker ActiveQueryTracker) generateIndices(maxConcurrent int) {
+	for i := 0; i < maxConcurrent; i++ {
+		tracker.getNextIndex <- 1 + (i * entrySize)
+	}
+}
+
+func (tracker ActiveQueryTracker) GetMaxConcurrent() int {
+	return tracker.maxConcurrent
+}
+
+func (tracker ActiveQueryTracker) Delete(insertIndex int) {
+	copy(tracker.mmapedFile[insertIndex:], strings.Repeat("\x00", entrySize))
+	tracker.getNextIndex <- insertIndex
+}
+
+func (tracker ActiveQueryTracker) Insert(ctx context.Context, query string) (int, error) {
+	select {
+	case i := <-tracker.getNextIndex:
+		fileBytes := tracker.mmapedFile
+		entry := newJSONEntry(query, tracker.logger)
+		start, end := i, i+entrySize
+
+		copy(fileBytes[start:], entry)
+		copy(fileBytes[end-1:], ",")
+		return i, nil
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}

--- a/pkg/promql/query_logger_test.go
+++ b/pkg/promql/query_logger_test.go
@@ -1,0 +1,175 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestQueryLogging(t *testing.T) {
+	fileAsBytes := make([]byte, 4096)
+	queryLogger := ActiveQueryTracker{
+		mmapedFile:   fileAsBytes,
+		logger:       nil,
+		getNextIndex: make(chan int, 4),
+	}
+
+	queryLogger.generateIndices(4)
+	veryLongString := "MassiveQueryThatNeverEndsAndExceedsTwoHundredBytesWhichIsTheSizeOfEntrySizeAndShouldThusBeTruncatedAndIamJustGoingToRepeatTheSameCharactersAgainProbablyBecauseWeAreStillOnlyHalfWayDoneOrMaybeNotOrMaybeMassiveQueryThatNeverEndsAndExceedsTwoHundredBytesWhichIsTheSizeOfEntrySizeAndShouldThusBeTruncatedAndIamJustGoingToRepeatTheSameCharactersAgainProbablyBecauseWeAreStillOnlyHalfWayDoneOrMaybeNotOrMaybeMassiveQueryThatNeverEndsAndExceedsTwoHundredBytesWhichIsTheSizeOfEntrySizeAndShouldThusBeTruncatedAndIamJustGoingToRepeatTheSameCharactersAgainProbablyBecauseWeAreStillOnlyHalfWayDoneOrMaybeNotOrMaybeMassiveQueryThatNeverEndsAndExceedsTwoHundredBytesWhichIsTheSizeOfEntrySizeAndShouldThusBeTruncatedAndIamJustGoingToRepeatTheSameCharactersAgainProbablyBecauseWeAreStillOnlyHalfWayDoneOrMaybeNotOrMaybeMassiveQueryThatNeverEndsAndExceedsTwoHundredBytesWhichIsTheSizeOfEntrySizeAndShouldThusBeTruncatedAndIamJustGoingToRepeatTheSameCharactersAgainProbablyBecauseWeAreStillOnlyHalfWayDoneOrMaybeNotOrMaybe"
+	queries := []string{
+		"TestQuery",
+		veryLongString,
+		"",
+		"SpecialCharQuery{host=\"2132132\", id=123123}",
+	}
+
+	want := []string{
+		`^{"query":"TestQuery","timestamp_sec":\d+}\x00*,$`,
+		`^{"query":"` + trimStringByBytes(veryLongString, entrySize-40) + `","timestamp_sec":\d+}\x00*,$`,
+		`^{"query":"","timestamp_sec":\d+}\x00*,$`,
+		`^{"query":"SpecialCharQuery{host=\\"2132132\\", id=123123}","timestamp_sec":\d+}\x00*,$`,
+	}
+
+	// Check for inserts of queries.
+	for i := 0; i < 4; i++ {
+		start := 1 + i*entrySize
+		end := start + entrySize
+
+		queryLogger.Insert(context.Background(), queries[i])
+
+		have := string(fileAsBytes[start:end])
+		if !regexp.MustCompile(want[i]).MatchString(have) {
+			t.Fatalf("Query not written correctly: %s.\nHave %s\nWant %s", queries[i], have, want[i])
+		}
+	}
+
+	// Check if all queries have been deleted.
+	for i := 0; i < 4; i++ {
+		queryLogger.Delete(1 + i*entrySize)
+	}
+	if !regexp.MustCompile(`^\x00+$`).Match(fileAsBytes[1 : 1+entrySize*4]) {
+		t.Fatalf("All queries not deleted properly. Have %s\nWant only null bytes \\x00", string(fileAsBytes[1:1+entrySize*4]))
+	}
+}
+
+func TestIndexReuse(t *testing.T) {
+	queryBytes := make([]byte, 1+3*entrySize)
+	queryLogger := ActiveQueryTracker{
+		mmapedFile:   queryBytes,
+		logger:       nil,
+		getNextIndex: make(chan int, 3),
+	}
+
+	queryLogger.generateIndices(3)
+	queryLogger.Insert(context.Background(), "TestQuery1")
+	queryLogger.Insert(context.Background(), "TestQuery2")
+	queryLogger.Insert(context.Background(), "TestQuery3")
+
+	queryLogger.Delete(1 + entrySize)
+	queryLogger.Delete(1)
+	newQuery2 := "ThisShouldBeInsertedAtIndex2"
+	newQuery1 := "ThisShouldBeInsertedAtIndex1"
+	queryLogger.Insert(context.Background(), newQuery2)
+	queryLogger.Insert(context.Background(), newQuery1)
+
+	want := []string{
+		`^{"query":"ThisShouldBeInsertedAtIndex1","timestamp_sec":\d+}\x00*,$`,
+		`^{"query":"ThisShouldBeInsertedAtIndex2","timestamp_sec":\d+}\x00*,$`,
+		`^{"query":"TestQuery3","timestamp_sec":\d+}\x00*,$`,
+	}
+
+	// Check all bytes and verify new query was inserted at index 2
+	for i := 0; i < 3; i++ {
+		start := 1 + i*entrySize
+		end := start + entrySize
+
+		have := queryBytes[start:end]
+		if !regexp.MustCompile(want[i]).Match(have) {
+			t.Fatalf("Index not reused properly:\nHave %s\nWant %s", string(queryBytes[start:end]), want[i])
+		}
+	}
+}
+
+func TestMMapFile(t *testing.T) {
+	file, err := ioutil.TempFile("", "mmapedFile")
+	testutil.Ok(t, err)
+
+	filename := file.Name()
+	defer os.Remove(filename)
+
+	fileAsBytes, err := getMMapedFile(filename, 2, nil)
+
+	testutil.Ok(t, err)
+	copy(fileAsBytes, "ab")
+
+	f, err := os.Open(filename)
+	testutil.Ok(t, err)
+
+	bytes := make([]byte, 4)
+	n, err := f.Read(bytes)
+
+	if n != 2 || err != nil {
+		t.Fatalf("Error reading file")
+	}
+
+	if string(bytes[:2]) != string(fileAsBytes) {
+		t.Fatalf("Mmap failed")
+	}
+}
+
+func TestParseBrokenJSON(t *testing.T) {
+	for _, tc := range []struct {
+		b []byte
+
+		ok  bool
+		out string
+	}{
+		{
+			b: []byte(""),
+		},
+		{
+			b: []byte("\x00\x00"),
+		},
+		{
+			b: []byte("\x00[\x00"),
+		},
+		{
+			b:   []byte("\x00[]\x00"),
+			ok:  true,
+			out: "[]",
+		},
+		{
+			b:   []byte("[\"up == 0\",\"rate(http_requests[2w]\"]\x00\x00\x00"),
+			ok:  true,
+			out: "[\"up == 0\",\"rate(http_requests[2w]\"]",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			ok, out := parseBrokenJSON(tc.b)
+			if tc.ok != ok {
+				t.Fatalf("expected %t, got %t", tc.ok, ok)
+				return
+			}
+			if ok && tc.out != out {
+				t.Fatalf("expected %s, got %s", tc.out, out)
+			}
+		})
+	}
+}

--- a/pkg/promql/test.go
+++ b/pkg/promql/test.go
@@ -1,0 +1,701 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+var (
+	minNormal = math.Float64frombits(0x0010000000000000) // The smallest positive normal value of type float64.
+
+	patSpace       = regexp.MustCompile("[\t ]+")
+	patLoad        = regexp.MustCompile(`^load\s+(.+?)$`)
+	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|ordered))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
+)
+
+const (
+	epsilon = 0.000001 // Relative error allowed for sample values.
+)
+
+var testStartTime = time.Unix(0, 0).UTC()
+
+// Test is a sequence of read and write commands that are run
+// against a test storage.
+type Test struct {
+	testutil.T
+
+	cmds []testCommand
+
+	storage *teststorage.TestStorage
+
+	queryEngine *Engine
+	context     context.Context
+	cancelCtx   context.CancelFunc
+}
+
+// NewTest returns an initialized empty Test.
+func NewTest(t testutil.T, input string) (*Test, error) {
+	test := &Test{
+		T:    t,
+		cmds: []testCommand{},
+	}
+	err := test.parse(input)
+	test.clear()
+
+	return test, err
+}
+
+func newTestFromFile(t testutil.T, filename string) (*Test, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return NewTest(t, string(content))
+}
+
+// QueryEngine returns the test's query engine.
+func (t *Test) QueryEngine() *Engine {
+	return t.queryEngine
+}
+
+// Queryable allows querying the test data.
+func (t *Test) Queryable() storage.Queryable {
+	return t.storage
+}
+
+// Context returns the test's context.
+func (t *Test) Context() context.Context {
+	return t.context
+}
+
+// Storage returns the test's storage.
+func (t *Test) Storage() storage.Storage {
+	return t.storage
+}
+
+// TSDB returns test's TSDB.
+func (t *Test) TSDB() *tsdb.DB {
+	return t.storage.DB
+}
+
+func raise(line int, format string, v ...interface{}) error {
+	return &parser.ParseErr{
+		LineOffset: line,
+		Err:        errors.Errorf(format, v...),
+	}
+}
+
+func parseLoad(lines []string, i int) (int, *loadCmd, error) {
+	if !patLoad.MatchString(lines[i]) {
+		return i, nil, raise(i, "invalid load command. (load <step:duration>)")
+	}
+	parts := patLoad.FindStringSubmatch(lines[i])
+
+	gap, err := model.ParseDuration(parts[1])
+	if err != nil {
+		return i, nil, raise(i, "invalid step definition %q: %s", parts[1], err)
+	}
+	cmd := newLoadCmd(time.Duration(gap))
+	for i+1 < len(lines) {
+		i++
+		defLine := lines[i]
+		if len(defLine) == 0 {
+			i--
+			break
+		}
+		metric, vals, err := parser.ParseSeriesDesc(defLine)
+		if err != nil {
+			if perr, ok := err.(*parser.ParseErr); ok {
+				perr.LineOffset = i
+			}
+			return i, nil, err
+		}
+		cmd.set(metric, vals...)
+	}
+	return i, cmd, nil
+}
+
+func (t *Test) parseEval(lines []string, i int) (int, *evalCmd, error) {
+	if !patEvalInstant.MatchString(lines[i]) {
+		return i, nil, raise(i, "invalid evaluation command. (eval[_fail|_ordered] instant [at <offset:duration>] <query>")
+	}
+	parts := patEvalInstant.FindStringSubmatch(lines[i])
+	var (
+		mod  = parts[1]
+		at   = parts[2]
+		expr = parts[3]
+	)
+	_, err := parser.ParseExpr(expr)
+	if err != nil {
+		if perr, ok := err.(*parser.ParseErr); ok {
+			perr.LineOffset = i
+			posOffset := parser.Pos(strings.Index(lines[i], expr))
+			perr.PositionRange.Start += posOffset
+			perr.PositionRange.End += posOffset
+			perr.Query = lines[i]
+		}
+		return i, nil, err
+	}
+
+	offset, err := model.ParseDuration(at)
+	if err != nil {
+		return i, nil, raise(i, "invalid step definition %q: %s", parts[1], err)
+	}
+	ts := testStartTime.Add(time.Duration(offset))
+
+	cmd := newEvalCmd(expr, ts, i+1)
+	switch mod {
+	case "ordered":
+		cmd.ordered = true
+	case "fail":
+		cmd.fail = true
+	}
+
+	for j := 1; i+1 < len(lines); j++ {
+		i++
+		defLine := lines[i]
+		if len(defLine) == 0 {
+			i--
+			break
+		}
+		if f, err := parseNumber(defLine); err == nil {
+			cmd.expect(0, nil, parser.SequenceValue{Value: f})
+			break
+		}
+		metric, vals, err := parser.ParseSeriesDesc(defLine)
+		if err != nil {
+			if perr, ok := err.(*parser.ParseErr); ok {
+				perr.LineOffset = i
+			}
+			return i, nil, err
+		}
+
+		// Currently, we are not expecting any matrices.
+		if len(vals) > 1 {
+			return i, nil, raise(i, "expecting multiple values in instant evaluation not allowed")
+		}
+		cmd.expect(j, metric, vals...)
+	}
+	return i, cmd, nil
+}
+
+// getLines returns trimmed lines after removing the comments.
+func getLines(input string) []string {
+	lines := strings.Split(input, "\n")
+	for i, l := range lines {
+		l = strings.TrimSpace(l)
+		if strings.HasPrefix(l, "#") {
+			l = ""
+		}
+		lines[i] = l
+	}
+	return lines
+}
+
+// parse the given command sequence and appends it to the test.
+func (t *Test) parse(input string) error {
+	lines := getLines(input)
+	var err error
+	// Scan for steps line by line.
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if len(l) == 0 {
+			continue
+		}
+		var cmd testCommand
+
+		switch c := strings.ToLower(patSpace.Split(l, 2)[0]); {
+		case c == "clear":
+			cmd = &clearCmd{}
+		case c == "load":
+			i, cmd, err = parseLoad(lines, i)
+		case strings.HasPrefix(c, "eval"):
+			i, cmd, err = t.parseEval(lines, i)
+		default:
+			return raise(i, "invalid command %q", l)
+		}
+		if err != nil {
+			return err
+		}
+		t.cmds = append(t.cmds, cmd)
+	}
+	return nil
+}
+
+// testCommand is an interface that ensures that only the package internal
+// types can be a valid command for a test.
+type testCommand interface {
+	testCmd()
+}
+
+func (*clearCmd) testCmd() {}
+func (*loadCmd) testCmd()  {}
+func (*evalCmd) testCmd()  {}
+
+// loadCmd is a command that loads sequences of sample values for specific
+// metrics into the storage.
+type loadCmd struct {
+	gap     time.Duration
+	metrics map[uint64]labels.Labels
+	defs    map[uint64][]Point
+}
+
+func newLoadCmd(gap time.Duration) *loadCmd {
+	return &loadCmd{
+		gap:     gap,
+		metrics: map[uint64]labels.Labels{},
+		defs:    map[uint64][]Point{},
+	}
+}
+
+func (cmd loadCmd) String() string {
+	return "load"
+}
+
+// set a sequence of sample values for the given metric.
+func (cmd *loadCmd) set(m labels.Labels, vals ...parser.SequenceValue) {
+	h := m.Hash()
+
+	samples := make([]Point, 0, len(vals))
+	ts := testStartTime
+	for _, v := range vals {
+		if !v.Omitted {
+			samples = append(samples, Point{
+				T: ts.UnixNano() / int64(time.Millisecond/time.Nanosecond),
+				V: v.Value,
+			})
+		}
+		ts = ts.Add(cmd.gap)
+	}
+	cmd.defs[h] = samples
+	cmd.metrics[h] = m
+}
+
+// append the defined time series to the storage.
+func (cmd *loadCmd) append(a storage.Appender) error {
+	for h, smpls := range cmd.defs {
+		m := cmd.metrics[h]
+
+		for _, s := range smpls {
+			if _, err := a.Add(m, s.T, s.V); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// evalCmd is a command that evaluates an expression for the given time (range)
+// and expects a specific result.
+type evalCmd struct {
+	expr  string
+	start time.Time
+	line  int
+
+	fail, ordered bool
+
+	metrics  map[uint64]labels.Labels
+	expected map[uint64]entry
+}
+
+type entry struct {
+	pos  int
+	vals []parser.SequenceValue
+}
+
+func (e entry) String() string {
+	return fmt.Sprintf("%d: %s", e.pos, e.vals)
+}
+
+func newEvalCmd(expr string, start time.Time, line int) *evalCmd {
+	return &evalCmd{
+		expr:  expr,
+		start: start,
+		line:  line,
+
+		metrics:  map[uint64]labels.Labels{},
+		expected: map[uint64]entry{},
+	}
+}
+
+func (ev *evalCmd) String() string {
+	return "eval"
+}
+
+// expect adds a new metric with a sequence of values to the set of expected
+// results for the query.
+func (ev *evalCmd) expect(pos int, m labels.Labels, vals ...parser.SequenceValue) {
+	if m == nil {
+		ev.expected[0] = entry{pos: pos, vals: vals}
+		return
+	}
+	h := m.Hash()
+	ev.metrics[h] = m
+	ev.expected[h] = entry{pos: pos, vals: vals}
+}
+
+// compareResult compares the result value with the defined expectation.
+func (ev *evalCmd) compareResult(result parser.Value) error {
+	switch val := result.(type) {
+	case Matrix:
+		return errors.New("received range result on instant evaluation")
+
+	case Vector:
+		seen := map[uint64]bool{}
+		for pos, v := range val {
+			fp := v.Metric.Hash()
+			if _, ok := ev.metrics[fp]; !ok {
+				return errors.Errorf("unexpected metric %s in result", v.Metric)
+			}
+			exp := ev.expected[fp]
+			if ev.ordered && exp.pos != pos+1 {
+				return errors.Errorf("expected metric %s with %v at position %d but was at %d", v.Metric, exp.vals, exp.pos, pos+1)
+			}
+			if !almostEqual(exp.vals[0].Value, v.V) {
+				return errors.Errorf("expected %v for %s but got %v", exp.vals[0].Value, v.Metric, v.V)
+			}
+
+			seen[fp] = true
+		}
+		for fp, expVals := range ev.expected {
+			if !seen[fp] {
+				fmt.Println("vector result", len(val), ev.expr)
+				for _, ss := range val {
+					fmt.Println("    ", ss.Metric, ss.Point)
+				}
+				return errors.Errorf("expected metric %s with %v not found", ev.metrics[fp], expVals)
+			}
+		}
+
+	case Scalar:
+		if !almostEqual(ev.expected[0].vals[0].Value, val.V) {
+			return errors.Errorf("expected Scalar %v but got %v", val.V, ev.expected[0].vals[0].Value)
+		}
+
+	default:
+		panic(errors.Errorf("promql.Test.compareResult: unexpected result type %T", result))
+	}
+	return nil
+}
+
+// clearCmd is a command that wipes the test's storage state.
+type clearCmd struct{}
+
+func (cmd clearCmd) String() string {
+	return "clear"
+}
+
+// Run executes the command sequence of the test. Until the maximum error number
+// is reached, evaluation errors do not terminate execution.
+func (t *Test) Run() error {
+	for _, cmd := range t.cmds {
+		// TODO(fabxc): aggregate command errors, yield diffs for result
+		// comparison errors.
+		if err := t.exec(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// exec processes a single step of the test.
+func (t *Test) exec(tc testCommand) error {
+	switch cmd := tc.(type) {
+	case *clearCmd:
+		t.clear()
+
+	case *loadCmd:
+		app := t.storage.Appender()
+		if err := cmd.append(app); err != nil {
+			app.Rollback()
+			return err
+		}
+
+		if err := app.Commit(); err != nil {
+			return err
+		}
+
+	case *evalCmd:
+		q, err := t.QueryEngine().NewInstantQuery(t.storage, cmd.expr, cmd.start)
+		if err != nil {
+			return err
+		}
+		defer q.Close()
+		res := q.Exec(t.context)
+		if res.Err != nil {
+			if cmd.fail {
+				return nil
+			}
+			return errors.Wrapf(res.Err, "error evaluating query %q (line %d)", cmd.expr, cmd.line)
+		}
+		if res.Err == nil && cmd.fail {
+			return errors.Errorf("expected error evaluating query %q (line %d) but got none", cmd.expr, cmd.line)
+		}
+
+		err = cmd.compareResult(res.Value)
+		if err != nil {
+			return errors.Wrapf(err, "error in %s %s", cmd, cmd.expr)
+		}
+
+		// Check query returns same result in range mode,
+		// by checking against the middle step.
+		q, err = t.queryEngine.NewRangeQuery(t.storage, cmd.expr, cmd.start.Add(-time.Minute), cmd.start.Add(time.Minute), time.Minute)
+		if err != nil {
+			return err
+		}
+		rangeRes := q.Exec(t.context)
+		if rangeRes.Err != nil {
+			return errors.Wrapf(rangeRes.Err, "error evaluating query %q (line %d) in range mode", cmd.expr, cmd.line)
+		}
+		defer q.Close()
+		if cmd.ordered {
+			// Ordering isn't defined for range queries.
+			return nil
+		}
+		mat := rangeRes.Value.(Matrix)
+		vec := make(Vector, 0, len(mat))
+		for _, series := range mat {
+			for _, point := range series.Points {
+				if point.T == timeMilliseconds(cmd.start) {
+					vec = append(vec, Sample{Metric: series.Metric, Point: point})
+					break
+				}
+			}
+		}
+		if _, ok := res.Value.(Scalar); ok {
+			err = cmd.compareResult(Scalar{V: vec[0].Point.V})
+		} else {
+			err = cmd.compareResult(vec)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "error in %s %s (line %d) rande mode", cmd, cmd.expr, cmd.line)
+		}
+
+	default:
+		panic("promql.Test.exec: unknown test command type")
+	}
+	return nil
+}
+
+// clear the current test storage of all inserted samples.
+func (t *Test) clear() {
+	if t.storage != nil {
+		if err := t.storage.Close(); err != nil {
+			t.T.Fatalf("closing test storage: %s", err)
+		}
+	}
+	if t.cancelCtx != nil {
+		t.cancelCtx()
+	}
+	t.storage = teststorage.New(t)
+
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10000,
+		Timeout:    100 * time.Second,
+	}
+
+	t.queryEngine = NewEngine(opts)
+	t.context, t.cancelCtx = context.WithCancel(context.Background())
+}
+
+// Close closes resources associated with the Test.
+func (t *Test) Close() {
+	t.cancelCtx()
+
+	if err := t.storage.Close(); err != nil {
+		t.T.Fatalf("closing test storage: %s", err)
+	}
+}
+
+// samplesAlmostEqual returns true if the two sample lines only differ by a
+// small relative error in their sample value.
+func almostEqual(a, b float64) bool {
+	// NaN has no equality but for testing we still want to know whether both values
+	// are NaN.
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+
+	// Cf. http://floating-point-gui.de/errors/comparison/
+	if a == b {
+		return true
+	}
+
+	diff := math.Abs(a - b)
+
+	if a == 0 || b == 0 || diff < minNormal {
+		return diff < epsilon*minNormal
+	}
+	return diff/(math.Abs(a)+math.Abs(b)) < epsilon
+}
+
+func parseNumber(s string) (float64, error) {
+	n, err := strconv.ParseInt(s, 0, 64)
+	f := float64(n)
+	if err != nil {
+		f, err = strconv.ParseFloat(s, 64)
+	}
+	if err != nil {
+		return 0, errors.Wrap(err, "error parsing number")
+	}
+	return f, nil
+}
+
+// LazyLoader lazily loads samples into storage.
+// This is specifically implemented for unit testing of rules.
+type LazyLoader struct {
+	testutil.T
+
+	loadCmd *loadCmd
+
+	storage storage.Storage
+
+	queryEngine *Engine
+	context     context.Context
+	cancelCtx   context.CancelFunc
+}
+
+// NewLazyLoader returns an initialized empty LazyLoader.
+func NewLazyLoader(t testutil.T, input string) (*LazyLoader, error) {
+	ll := &LazyLoader{
+		T: t,
+	}
+	err := ll.parse(input)
+	ll.clear()
+	return ll, err
+}
+
+// parse the given load command.
+func (ll *LazyLoader) parse(input string) error {
+	lines := getLines(input)
+	// Accepts only 'load' command.
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if len(l) == 0 {
+			continue
+		}
+		if strings.ToLower(patSpace.Split(l, 2)[0]) == "load" {
+			_, cmd, err := parseLoad(lines, i)
+			if err != nil {
+				return err
+			}
+			ll.loadCmd = cmd
+			return nil
+		}
+
+		return raise(i, "invalid command %q", l)
+	}
+	return errors.New("no \"load\" command found")
+}
+
+// clear the current test storage of all inserted samples.
+func (ll *LazyLoader) clear() {
+	if ll.storage != nil {
+		if err := ll.storage.Close(); err != nil {
+			ll.T.Fatalf("closing test storage: %s", err)
+		}
+	}
+	if ll.cancelCtx != nil {
+		ll.cancelCtx()
+	}
+	ll.storage = teststorage.New(ll)
+
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10000,
+		Timeout:    100 * time.Second,
+	}
+
+	ll.queryEngine = NewEngine(opts)
+	ll.context, ll.cancelCtx = context.WithCancel(context.Background())
+}
+
+// appendTill appends the defined time series to the storage till the given timestamp (in milliseconds).
+func (ll *LazyLoader) appendTill(ts int64) error {
+	app := ll.storage.Appender()
+	for h, smpls := range ll.loadCmd.defs {
+		m := ll.loadCmd.metrics[h]
+		for i, s := range smpls {
+			if s.T > ts {
+				// Removing the already added samples.
+				ll.loadCmd.defs[h] = smpls[i:]
+				break
+			}
+			if _, err := app.Add(m, s.T, s.V); err != nil {
+				return err
+			}
+			if i == len(smpls)-1 {
+				ll.loadCmd.defs[h] = nil
+			}
+		}
+	}
+	return app.Commit()
+}
+
+// WithSamplesTill loads the samples till given timestamp and executes the given function.
+func (ll *LazyLoader) WithSamplesTill(ts time.Time, fn func(error)) {
+	tsMilli := ts.Sub(time.Unix(0, 0).UTC()) / time.Millisecond
+	fn(ll.appendTill(int64(tsMilli)))
+}
+
+// QueryEngine returns the LazyLoader's query engine.
+func (ll *LazyLoader) QueryEngine() *Engine {
+	return ll.queryEngine
+}
+
+// Queryable allows querying the LazyLoader's data.
+// Note: only the samples till the max timestamp used
+//       in `WithSamplesTill` can be queried.
+func (ll *LazyLoader) Queryable() storage.Queryable {
+	return ll.storage
+}
+
+// Context returns the LazyLoader's context.
+func (ll *LazyLoader) Context() context.Context {
+	return ll.context
+}
+
+// Storage returns the LazyLoader's storage.
+func (ll *LazyLoader) Storage() storage.Storage {
+	return ll.storage
+}
+
+// Close closes resources associated with the LazyLoader.
+func (ll *LazyLoader) Close() {
+	ll.cancelCtx()
+
+	if err := ll.storage.Close(); err != nil {
+		ll.T.Fatalf("closing test storage: %s", err)
+	}
+}

--- a/pkg/promql/test_test.go
+++ b/pkg/promql/test_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestLazyLoader_WithSamplesTill(t *testing.T) {
+	type testCase struct {
+		ts             time.Time
+		series         []Series // Each series is checked separately. Need not mention all series here.
+		checkOnlyError bool     // If this is true, series is not checked.
+	}
+
+	cases := []struct {
+		loadString string
+		// These testCases are run in sequence. So the testCase being run is dependent on the previous testCase.
+		testCases []testCase
+	}{
+		{
+			loadString: `
+				load 10s
+					metric1 1+1x10
+			`,
+			testCases: []testCase{
+				{
+					ts: time.Unix(40, 0),
+					series: []Series{
+						{
+							Metric: labels.FromStrings("__name__", "metric1"),
+							Points: []Point{
+								{0, 1}, {10000, 2}, {20000, 3}, {30000, 4}, {40000, 5},
+							},
+						},
+					},
+				},
+				{
+					ts: time.Unix(10, 0),
+					series: []Series{
+						{
+							Metric: labels.FromStrings("__name__", "metric1"),
+							Points: []Point{
+								{0, 1}, {10000, 2}, {20000, 3}, {30000, 4}, {40000, 5},
+							},
+						},
+					},
+				},
+				{
+					ts: time.Unix(60, 0),
+					series: []Series{
+						{
+							Metric: labels.FromStrings("__name__", "metric1"),
+							Points: []Point{
+								{0, 1}, {10000, 2}, {20000, 3}, {30000, 4}, {40000, 5}, {50000, 6}, {60000, 7},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			loadString: `
+				load 10s
+					metric1 1+0x5
+					metric2 1+1x100
+			`,
+			testCases: []testCase{
+				{ // Adds all samples of metric1.
+					ts: time.Unix(70, 0),
+					series: []Series{
+						{
+							Metric: labels.FromStrings("__name__", "metric1"),
+							Points: []Point{
+								{0, 1}, {10000, 1}, {20000, 1}, {30000, 1}, {40000, 1}, {50000, 1},
+							},
+						},
+						{
+							Metric: labels.FromStrings("__name__", "metric2"),
+							Points: []Point{
+								{0, 1}, {10000, 2}, {20000, 3}, {30000, 4}, {40000, 5}, {50000, 6}, {60000, 7}, {70000, 8},
+							},
+						},
+					},
+				},
+				{ // This tests fix for https://github.com/prometheus/prometheus/issues/5064.
+					ts:             time.Unix(300, 0),
+					checkOnlyError: true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		suite, err := NewLazyLoader(t, c.loadString)
+		testutil.Ok(t, err)
+		defer suite.Close()
+
+		for _, tc := range c.testCases {
+			suite.WithSamplesTill(tc.ts, func(err error) {
+				testutil.Ok(t, err)
+				if tc.checkOnlyError {
+					return
+				}
+
+				// Check the series.
+				queryable := suite.Queryable()
+				querier, err := queryable.Querier(suite.Context(), math.MinInt64, math.MaxInt64)
+				testutil.Ok(t, err)
+				for _, s := range tc.series {
+					var matchers []*labels.Matcher
+					for _, label := range s.Metric {
+						m, err := labels.NewMatcher(labels.MatchEqual, label.Name, label.Value)
+						testutil.Ok(t, err)
+						matchers = append(matchers, m)
+					}
+
+					// Get the series for the matcher.
+					ss, _, err := querier.Select(false, nil, matchers...)
+					testutil.Ok(t, err)
+					testutil.Assert(t, ss.Next(), "")
+					storageSeries := ss.At()
+					testutil.Assert(t, !ss.Next(), "Expecting only 1 series")
+
+					// Convert `storage.Series` to `promql.Series`.
+					got := Series{
+						Metric: storageSeries.Labels(),
+					}
+					it := storageSeries.Iterator()
+					for it.Next() {
+						t, v := it.At()
+						got.Points = append(got.Points, Point{T: t, V: v})
+					}
+					testutil.Ok(t, it.Err())
+
+					testutil.Equals(t, s, got)
+				}
+			})
+		}
+	}
+}

--- a/pkg/promql/value.go
+++ b/pkg/promql/value.go
@@ -1,0 +1,306 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func (Matrix) Type() parser.ValueType { return parser.ValueTypeMatrix }
+func (Vector) Type() parser.ValueType { return parser.ValueTypeVector }
+func (Scalar) Type() parser.ValueType { return parser.ValueTypeScalar }
+func (String) Type() parser.ValueType { return parser.ValueTypeString }
+
+// String represents a string value.
+type String struct {
+	T int64
+	V string
+}
+
+func (s String) String() string {
+	return s.V
+}
+
+func (s String) MarshalJSON() ([]byte, error) {
+	return json.Marshal([...]interface{}{float64(s.T) / 1000, s.V})
+}
+
+// Scalar is a data point that's explicitly not associated with a metric.
+type Scalar struct {
+	T int64
+	V float64
+}
+
+func (s Scalar) String() string {
+	v := strconv.FormatFloat(s.V, 'f', -1, 64)
+	return fmt.Sprintf("scalar: %v @[%v]", v, s.T)
+}
+
+func (s Scalar) MarshalJSON() ([]byte, error) {
+	v := strconv.FormatFloat(s.V, 'f', -1, 64)
+	return json.Marshal([...]interface{}{float64(s.T) / 1000, v})
+}
+
+// Series is a stream of data points belonging to a metric.
+type Series struct {
+	Metric labels.Labels `json:"metric"`
+	Points []Point       `json:"values"`
+}
+
+func (s Series) String() string {
+	vals := make([]string, len(s.Points))
+	for i, v := range s.Points {
+		vals[i] = v.String()
+	}
+	return fmt.Sprintf("%s =>\n%s", s.Metric, strings.Join(vals, "\n"))
+}
+
+// Point represents a single data point for a given timestamp.
+type Point struct {
+	T int64
+	V float64
+}
+
+func (p Point) String() string {
+	v := strconv.FormatFloat(p.V, 'f', -1, 64)
+	return fmt.Sprintf("%v @[%v]", v, p.T)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (p Point) MarshalJSON() ([]byte, error) {
+	v := strconv.FormatFloat(p.V, 'f', -1, 64)
+	return json.Marshal([...]interface{}{float64(p.T) / 1000, v})
+}
+
+// Sample is a single sample belonging to a metric.
+type Sample struct {
+	Point
+
+	Metric labels.Labels
+}
+
+func (s Sample) String() string {
+	return fmt.Sprintf("%s => %s", s.Metric, s.Point)
+}
+
+func (s Sample) MarshalJSON() ([]byte, error) {
+	v := struct {
+		M labels.Labels `json:"metric"`
+		V Point         `json:"value"`
+	}{
+		M: s.Metric,
+		V: s.Point,
+	}
+	return json.Marshal(v)
+}
+
+// Vector is basically only an alias for model.Samples, but the
+// contract is that in a Vector, all Samples have the same timestamp.
+type Vector []Sample
+
+func (vec Vector) String() string {
+	entries := make([]string, len(vec))
+	for i, s := range vec {
+		entries[i] = s.String()
+	}
+	return strings.Join(entries, "\n")
+}
+
+// ContainsSameLabelset checks if a vector has samples with the same labelset
+// Such a behavior is semantically undefined
+// https://github.com/prometheus/prometheus/issues/4562
+func (vec Vector) ContainsSameLabelset() bool {
+	l := make(map[uint64]struct{}, len(vec))
+	for _, s := range vec {
+		hash := s.Metric.Hash()
+		if _, ok := l[hash]; ok {
+			return true
+		}
+		l[hash] = struct{}{}
+	}
+	return false
+}
+
+// Matrix is a slice of Series that implements sort.Interface and
+// has a String method.
+type Matrix []Series
+
+func (m Matrix) String() string {
+	// TODO(fabxc): sort, or can we rely on order from the querier?
+	strs := make([]string, len(m))
+
+	for i, ss := range m {
+		strs[i] = ss.String()
+	}
+
+	return strings.Join(strs, "\n")
+}
+
+// TotalSamples returns the total number of samples in the series within a matrix.
+func (m Matrix) TotalSamples() int {
+	numSamples := 0
+	for _, series := range m {
+		numSamples += len(series.Points)
+	}
+	return numSamples
+}
+
+func (m Matrix) Len() int           { return len(m) }
+func (m Matrix) Less(i, j int) bool { return labels.Compare(m[i].Metric, m[j].Metric) < 0 }
+func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+// ContainsSameLabelset checks if a matrix has samples with the same labelset
+// Such a behavior is semantically undefined
+// https://github.com/prometheus/prometheus/issues/4562
+func (m Matrix) ContainsSameLabelset() bool {
+	l := make(map[uint64]struct{}, len(m))
+	for _, ss := range m {
+		hash := ss.Metric.Hash()
+		if _, ok := l[hash]; ok {
+			return true
+		}
+		l[hash] = struct{}{}
+	}
+	return false
+}
+
+// Result holds the resulting value of an execution or an error
+// if any occurred.
+type Result struct {
+	Err      error
+	Value    parser.Value
+	Warnings storage.Warnings
+}
+
+// Vector returns a Vector if the result value is one. An error is returned if
+// the result was an error or the result value is not a Vector.
+func (r *Result) Vector() (Vector, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	v, ok := r.Value.(Vector)
+	if !ok {
+		return nil, errors.New("query result is not a Vector")
+	}
+	return v, nil
+}
+
+// Matrix returns a Matrix. An error is returned if
+// the result was an error or the result value is not a Matrix.
+func (r *Result) Matrix() (Matrix, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	v, ok := r.Value.(Matrix)
+	if !ok {
+		return nil, errors.New("query result is not a range Vector")
+	}
+	return v, nil
+}
+
+// Scalar returns a Scalar value. An error is returned if
+// the result was an error or the result value is not a Scalar.
+func (r *Result) Scalar() (Scalar, error) {
+	if r.Err != nil {
+		return Scalar{}, r.Err
+	}
+	v, ok := r.Value.(Scalar)
+	if !ok {
+		return Scalar{}, errors.New("query result is not a Scalar")
+	}
+	return v, nil
+}
+
+func (r *Result) String() string {
+	if r.Err != nil {
+		return r.Err.Error()
+	}
+	if r.Value == nil {
+		return ""
+	}
+	return r.Value.String()
+}
+
+// StorageSeries simulates promql.Series as storage.Series.
+type StorageSeries struct {
+	series Series
+}
+
+// NewStorageSeries returns a StorageSeries from a Series.
+func NewStorageSeries(series Series) *StorageSeries {
+	return &StorageSeries{
+		series: series,
+	}
+}
+
+func (ss *StorageSeries) Labels() labels.Labels {
+	return ss.series.Metric
+}
+
+// Iterator returns a new iterator of the data of the series.
+func (ss *StorageSeries) Iterator() chunkenc.Iterator {
+	return newStorageSeriesIterator(ss.series)
+}
+
+type storageSeriesIterator struct {
+	points []Point
+	curr   int
+}
+
+func newStorageSeriesIterator(series Series) *storageSeriesIterator {
+	return &storageSeriesIterator{
+		points: series.Points,
+		curr:   -1,
+	}
+}
+
+func (ssi *storageSeriesIterator) Seek(t int64) bool {
+	i := ssi.curr
+	if i < 0 {
+		i = 0
+	}
+	for ; i < len(ssi.points); i++ {
+		if ssi.points[i].T >= t {
+			ssi.curr = i
+			return true
+		}
+	}
+	ssi.curr = len(ssi.points) - 1
+	return false
+}
+
+func (ssi *storageSeriesIterator) At() (t int64, v float64) {
+	p := ssi.points[ssi.curr]
+	return p.T, p.V
+}
+
+func (ssi *storageSeriesIterator) Next() bool {
+	ssi.curr++
+	return ssi.curr < len(ssi.points)
+}
+
+func (ssi *storageSeriesIterator) Err() error {
+	return nil
+}

--- a/pkg/query/query_engine.go
+++ b/pkg/query/query_engine.go
@@ -1,11 +1,12 @@
 package query
 
 import (
-	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/promql"
 	"math"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 )
 
 func NewEngine(logger log.Logger, queryTimeout time.Duration) *promql.Engine {

--- a/pkg/query/queryable.go
+++ b/pkg/query/queryable.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/pgmodel"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 )
 
 func NewQueryable(q pgmodel.Querier) *Queryable {
@@ -17,7 +19,7 @@ type Queryable struct {
 	q pgmodel.Querier
 }
 
-func (q Queryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (q Queryable) Querier(ctx context.Context, mint, maxt int64) (promql.Querier, error) {
 	return newQuerier(ctx, q.q, mint, maxt)
 }
 
@@ -45,6 +47,6 @@ func (q querier) Close() error {
 	return nil
 }
 
-func (q querier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return q.pgQuerier.Select(q.mint, q.maxt, sortSeries, hints, matchers...)
+func (q querier) Select(sortSeries bool, hints *storage.SelectHints, path []parser.Node, matchers ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
+	return q.pgQuerier.Select(q.mint, q.maxt, sortSeries, hints, path, matchers...)
 }


### PR DESCRIPTION
This PR Pushes some query processing logic from the PromQL engine into the database.

We modify the interaction between the query engine and the storage layer so that the storage layer now takes in the node-branch it's evaluating, and computes as much of the branch as it's capable of, returning the top-most node it computed. The engine then walks up the execution path, starting at that node, and performs the remainder of the computation.

This PR puts in the framework to accomplish this and tests it with one pushdown function `delta`, which serves as a proof of concept. Further PRs will be used to push down other functions and processing nodes.

The approach used here is limited in certain ways:
1) It is not meant to push down past branches that split. This may or may not be fundamental but is out of scope since it's rarely used.
2) We don't push down queries with subqueries. Again this is rarely used. Unsure how difficult this would be to implement.  