### PR TITLE
Fix race condition on labels

### DIFF
--- a/pkg/pgmodel/labels.go
+++ b/pkg/pgmodel/labels.go
@@ -129,8 +129,8 @@ func labelProtosToLabels(labelPairs []prompb.Label) (*Labels, string, error) {
 			if l.Name == MetricNameLabelName {
 				labels.metricName = l.Value
 			}
-			labels = SetLabels(str, labels)
 		}
+		labels = SetLabels(str, labels)
 	}
 
 	return labels, labels.metricName, err


### PR DESCRIPTION
The labels set was put in the interner in the wrong location, so it
could be read before it's fully written. This commit fixes it.