### PR TITLE
Implement promql meta endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ We describe how to use our pre-defined views and functions to work with the prom
 
 A Reference for our SQL API is [available here](docs/sql_api.md).
 
+### Prometheus HTTP API 
+
+The Timescale-Prometheus Connector can be used directly as a Prometheus Data Source in Grafana, or other software.
+
+It implements some endpoints of the currently stable (V1) 
+[Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api). 
+The API is accessible at `http://timescale_prometheus_connector:9201/api/v1` and can be used to execute instant or range
+PromQL queries against the data in TimescaleDB, as well as retrieve the metadata for label names and values.
+
+A Reference for the implemented endpoints of the Prometheus HTTP API is [available here](docs/prometheus_api.md)
+
 ## Advanced
 
 ### Configuring the Helm Chart

--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -217,25 +217,18 @@ func main() {
 	queryable := client.GetQueryable()
 	queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
 	queryHandler := timeHandler(httpRequestDuration, "query", api.Query(queryEngine, queryable))
-	router.Get("/query", queryHandler)
-	router.Post("/query", queryHandler)
 	router.Get("/api/v1/query", queryHandler)
 	router.Post("/api/v1/query", queryHandler)
 
 	queryRangeHandler := timeHandler(httpRequestDuration, "query_range", api.QueryRange(queryEngine, queryable))
-	router.Get("/query_range", queryRangeHandler)
-	router.Post("/query_range", queryRangeHandler)
 	router.Get("/api/v1/query_range", queryRangeHandler)
 	router.Post("/api/v1/query_range", queryRangeHandler)
 
 	labelsHandler := timeHandler(httpRequestDuration, "labels", api.Labels(queryable))
-	router.Get("/labels", labelsHandler)
-	router.Post("/labels", labelsHandler)
 	router.Get("/api/v1/labels", labelsHandler)
 	router.Post("/api/v1/labels", labelsHandler)
 
 	labelValuesHandler := timeHandler(httpRequestDuration, "label/:name/values", api.LabelValues(queryable))
-	router.Get("/label/:name/values", labelValuesHandler)
 	router.Get("/api/v1/label/:name/values", labelValuesHandler)
 
 	router.Get("/healthz", api.Health(client))

--- a/docs/prometheus_api.md
+++ b/docs/prometheus_api.md
@@ -1,0 +1,43 @@
+# Prometheus HTTP API reference
+
+The [Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/) defines endpoints
+for executing PromQL expression queries (instant and range), query metadata about the series and labels, retrieve 
+information about alerts, targets and the complete configuration of the prometheus server. 
+
+We implemented the endpoints for executing PromQL and labels metadata to allow the Timescale-Prometheus connector to be 
+used as a Prometheus compatible data-source in applications like Grafana. 
+
+<img src="./timescale-prometheus-arch.png" alt="Timescale-Prometheus Architecture Diagram" width="800"/>
+
+
+When requesting a query to run on data that is in the long-term storage through Prometheus, the query goes through the 
+following steps. 
+1. Query engine requests the data through the remote_read protocol;
+1. The connector translates the request to SQL statement with only a time range and label matchers applied;
+1. The database returns almost raw data;
+1. The connector marshals it into a format compatible with the remote_read protocol;
+1. The Query engine combines the local and remote data and applies any functions or aggregations before returning a 
+result.
+
+By having the Connector implement the PromQL APIs, the connector can:
+1. Parse the PromQL and translate it to a SQL statement that with a time range, label matchers, calculations and 
+aggregates to be pushed down;
+1. The database executes the query;
+1. A modified Prometheus Query Engine finalizes the calculation and marshals the data to a proper response.
+
+By using the Connector for PromQL queries directly a network trip is avoided, and TimescaleDB is better utilized to 
+actually perform some calculations. 
+
+## Implemented Endpoints
+
+|                 Name               |              Endpoint                   |                          Description                      | 
+|------------------------------------|-----------------------------------------|-----------------------------------------------------------|
+|[Instant Queries][instant-queries]  |`GET /api/v1/query``POST /api/v1/query`  |Evaluate an instant query at a single point in time        |
+|[Range Queries][range-queries]      |`GET /api/v1/query_range``POST /api/v1/query_range`|Evaluate an expression query over a range of time|
+|[Label Names][label-names]          |`GET /api/v1/labels``POST /api/v1/labels`|Return a list of label names                               |
+|[Label Values][label-values]        |`GET /api/v1/label/<label_name>/values`  |Return a list of label values for a provided label name    |
+
+[instant-queries]: (https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)
+[range-queries]: (https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries)
+[label-names]: (https://prometheus.io/docs/prometheus/latest/querying/api/#getting-label-names)
+[label-values]: (https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values)

--- a/docs/prometheus_api.md
+++ b/docs/prometheus_api.md
@@ -30,12 +30,12 @@ actually perform some calculations.
 
 ## Implemented Endpoints
 
-|                 Name               |              Endpoint                   |                          Description                      | 
-|------------------------------------|-----------------------------------------|-----------------------------------------------------------|
-|[Instant Queries][instant-queries]  |`GET /api/v1/query``POST /api/v1/query`  |Evaluate an instant query at a single point in time        |
-|[Range Queries][range-queries]      |`GET /api/v1/query_range``POST /api/v1/query_range`|Evaluate an expression query over a range of time|
-|[Label Names][label-names]          |`GET /api/v1/labels``POST /api/v1/labels`|Return a list of label names                               |
-|[Label Values][label-values]        |`GET /api/v1/label/<label_name>/values`  |Return a list of label values for a provided label name    |
+|               Name               |                Endpoint               |                      Description                      | 
+|----------------------------------|---------------------------------------|-------------------------------------------------------|
+|[Instant Queries][instant-queries]|`GET,POST /api/v1/query`               |Evaluate an instant query at a single point in time    |
+|[Range Queries][range-queries]    |`GET,POST /api/v1/query_range`         |Evaluate an expression query over a range of time      |
+|[Label Names][label-names]        |`GET,POST /api/v1/labels`              |Return a list of label names                           |
+|[Label Values][label-values]      |`GET /api/v1/label/<label_name>/values`|Return a list of label values for a provided label name|
 
 [instant-queries]: (https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)
 [range-queries]: (https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/jackc/pgx/v4 v4.4.1
 	github.com/jamiealquiza/envy v1.1.0
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K8mysFmDaM/h+o=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 )
 
-func Health(hc pgmodel.HealthChecker) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func Health(hc pgmodel.HealthChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		err := hc.HealthCheck()
 		if err != nil {
 			log.Warn("msg", "Healthcheck failed", err)
@@ -15,5 +15,5 @@ func Health(hc pgmodel.HealthChecker) http.Handler {
 			return
 		}
 		w.Header().Set("Content-Length", "0")
-	})
+	}
 }

--- a/pkg/api/label_values.go
+++ b/pkg/api/label_values.go
@@ -14,8 +14,6 @@ import (
 
 func LabelValues(queriable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-
 		ctx := r.Context()
 		name := route.Param(ctx, "name")
 		if !model.LabelNameRE.MatchString(name) {

--- a/pkg/api/label_values.go
+++ b/pkg/api/label_values.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 	"math"
 	"net/http"
@@ -26,13 +27,16 @@ func LabelValues(queriable *query.Queryable) http.Handler {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
-		names, warnings, err := querier.LabelValues(name)
+		var values labelsValue
+		values, warnings, err := querier.LabelValues(name)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
 
-		respond(w, names, warnings)
+		respondLabels(w, &promql.Result{
+			Value: values,
+		}, warnings)
 	})
 
 	return gziphandler.GzipHandler(hf)

--- a/pkg/api/label_values.go
+++ b/pkg/api/label_values.go
@@ -2,22 +2,31 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"github.com/NYTimes/gziphandler"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/route"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 	"math"
 	"net/http"
 )
 
-func Labels(queriable *query.Queryable) http.Handler {
+func LabelValues(queriable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 
+		ctx := r.Context()
+		name := route.Param(ctx, "name")
+		if !model.LabelNameRE.MatchString(name) {
+			respondError(w, http.StatusBadRequest, fmt.Errorf("invalid label name: %s", name), "bad_data")
+			return
+		}
 		querier, err := queriable.Querier(context.Background(), math.MinInt64, math.MaxInt64)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
-		names, warnings, err := querier.LabelNames()
+		names, warnings, err := querier.LabelValues(name)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"context"
+	"github.com/NYTimes/gziphandler"
+	"github.com/timescale/timescale-prometheus/pkg/query"
+	"math"
+	"net/http"
+)
+
+func Labels(queriable *query.Queryable) http.Handler {
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		querier, err := queriable.Querier(context.Background(), math.MinInt64, math.MaxInt64)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err, "internal")
+			return
+		}
+		names, _, err := querier.LabelNames()
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err, "internal")
+			return
+		}
+
+		respond(w, names, nil)
+	})
+
+	return gziphandler.GzipHandler(hf)
+}

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -2,11 +2,26 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/NYTimes/gziphandler"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 	"math"
 	"net/http"
+	"strings"
 )
+
+type labelsValue []string
+
+func (l labelsValue) Type() parser.ValueType {
+	return parser.ValueTypeNone
+}
+
+func (l labelsValue) String() string {
+	return strings.Join(l, "\n")
+}
 
 func Labels(queriable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -17,14 +32,25 @@ func Labels(queriable *query.Queryable) http.Handler {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
+		var names labelsValue
 		names, warnings, err := querier.LabelNames()
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
-
-		respond(w, names, warnings)
+		respondLabels(w, &promql.Result{
+			Value: names,
+		}, warnings)
 	})
 
 	return gziphandler.GzipHandler(hf)
+}
+
+func respondLabels(w http.ResponseWriter, res *promql.Result, warnings storage.Warnings) {
+	setHeaders(w, res, warnings)
+	resp := &response{
+		Status: "success",
+		Data:   res.Value,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -25,8 +25,6 @@ func (l labelsValue) String() string {
 
 func Labels(queriable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-
 		querier, err := queriable.Querier(context.Background(), math.MinInt64, math.MaxInt64)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")

--- a/pkg/api/labels_test.go
+++ b/pkg/api/labels_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/query"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestLabels(t *testing.T) {
+	_ = log.Init("debug")
+	testCases := []struct {
+		name        string
+		querier     *mockQuerier
+		expectCode  int
+		expectError string
+		canceled    bool
+	}{
+		{
+			name:        "Error on get label names",
+			expectCode:  http.StatusInternalServerError,
+			expectError: "internal",
+			querier:     &mockQuerier{labelNamesErr: fmt.Errorf("error on label names")},
+		}, {
+			name:       "All good",
+			expectCode: http.StatusOK,
+			querier:    &mockQuerier{labelNames: []string{"a"}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Labels(query.NewQueryable(tc.querier))
+			w := doLabels(t, handler)
+
+			if w.Code != tc.expectCode {
+				t.Errorf("Unexpected HTTP status code received: got %d wanted %d", w.Code, tc.expectCode)
+				return
+			}
+			if tc.expectError != "" {
+				var er errResponse
+				_ = json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&er)
+				if tc.expectError != er.ErrorType {
+					t.Errorf("expected error of type %s, got %s", tc.expectError, er.ErrorType)
+				}
+				return
+			}
+			var res response
+			_ = json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&res)
+			if len(res.Warnings) > 0 {
+				t.Errorf("unexpected warnings: %v", res.Warnings)
+			}
+			var resStr []string
+			for _, s := range res.Data.([]interface{}) {
+				resStr = append(resStr, s.(string))
+			}
+			if !reflect.DeepEqual(resStr, tc.querier.labelNames) {
+				t.Errorf("expected: %v, got: %v", tc.querier.labelNames, res.Data)
+			}
+		})
+
+	}
+
+}
+
+func doLabels(t *testing.T, queryHandler http.Handler) *httptest.ResponseRecorder {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:9090/labels", nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded; param=value",
+	)
+	w := httptest.NewRecorder()
+
+	queryHandler.ServeHTTP(w, req)
+	return w
+}

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -21,7 +21,6 @@ import (
 
 func Query(queryEngine *promql.Engine, queryable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		var ts time.Time
 		if t := r.FormValue("time"); t != "" {
 			var err error
@@ -80,6 +79,7 @@ func Query(queryEngine *promql.Engine, queryable *query.Queryable) http.Handler 
 }
 
 func setHeaders(w http.ResponseWriter, res *promql.Result, warnings storage.Warnings) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
 	if warnings != nil && len(warnings) > 0 {
 		w.Header().Set("Cache-Control", "no-store")

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"github.com/prometheus/prometheus/storage"
 	"io"
 	"math"
 	"net/http"
@@ -71,15 +72,15 @@ func Query(queryEngine *promql.Engine, queriable *query.Queryable) http.Handler 
 			return
 		}
 
-		respond(w, res)
+		respond(w, res, res.Warnings)
 	})
 
 	return gziphandler.GzipHandler(hf)
 }
 
-func respond(w http.ResponseWriter, res *promql.Result) {
+func respond(w http.ResponseWriter, res *promql.Result, warnings storage.Warnings) {
 	w.Header().Set("Content-Type", "application/json")
-	if len(res.Warnings) > 0 {
+	if warnings != nil && len(warnings) > 0 {
 		w.Header().Set("Cache-Control", "no-store")
 	}
 	w.WriteHeader(http.StatusOK)

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"github.com/prometheus/prometheus/storage"
 	"io"
 	"math"
 	"net/http"
@@ -14,13 +13,16 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/stats"
 	"github.com/timescale/timescale-prometheus/pkg/log"
 	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 
-func Query(queryEngine *promql.Engine, queriable *query.Queryable) http.Handler {
+func Query(queryEngine *promql.Engine, queryable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		var ts time.Time
 		if t := r.FormValue("time"); t != "" {
 			var err error
@@ -48,7 +50,7 @@ func Query(queryEngine *promql.Engine, queriable *query.Queryable) http.Handler 
 			defer cancel()
 		}
 
-		qry, err := queryEngine.NewInstantQuery(queriable, r.FormValue("query"), ts)
+		qry, err := queryEngine.NewInstantQuery(queryable, r.FormValue("query"), ts)
 		if err != nil {
 			log.Error("msg", "Query error", "err", err.Error())
 			respondError(w, http.StatusBadRequest, err, "bad_data")

--- a/pkg/api/query_range.go
+++ b/pkg/api/query_range.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"github.com/prometheus/prometheus/util/stats"
 	"net/http"
 
 	"github.com/NYTimes/gziphandler"
@@ -101,15 +100,7 @@ func QueryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.Han
 			return
 		}
 
-		var qs *stats.QueryStats
-		if r.FormValue("stats") != "" {
-			qs = stats.NewQueryStats(qry.Stats())
-		}
-		respond(w, &queryData{
-			Result:     res.Value,
-			ResultType: res.Value.Type(),
-			Stats:      qs,
-		}, res.Warnings)
+		respondQuery(w, res, res.Warnings)
 	})
 
 	return gziphandler.GzipHandler(hf)

--- a/pkg/api/query_range.go
+++ b/pkg/api/query_range.go
@@ -99,7 +99,7 @@ func QueryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.Han
 			return
 		}
 
-		respond(w, res)
+		respond(w, res.Value, res.Warnings)
 	})
 
 	return gziphandler.GzipHandler(hf)

--- a/pkg/api/query_range.go
+++ b/pkg/api/query_range.go
@@ -13,7 +13,6 @@ import (
 
 func QueryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		start, err := parseTime(r.FormValue("start"))
 		if err != nil {
 			log.Info("msg", "Query bad request:"+err.Error())

--- a/pkg/api/query_range_test.go
+++ b/pkg/api/query_range_test.go
@@ -110,7 +110,7 @@ func TestRangedQuery(t *testing.T) {
 			timeout:     "1s",
 			metric:      "m",
 			querier: &mockQuerier{
-				timeToSleep: 2 * time.Second,
+				timeToSleepOnSelect: 2 * time.Second,
 			},
 		}, {
 			name:        "Cancel query",
@@ -130,7 +130,7 @@ func TestRangedQuery(t *testing.T) {
 			expectCode:  http.StatusUnprocessableEntity,
 			expectError: "execution",
 			metric:      "m",
-			querier:     &mockQuerier{err: fmt.Errorf("some error")},
+			querier:     &mockQuerier{selectErr: fmt.Errorf("some error")},
 			timeout:     "30s",
 		}, {
 			name:       "All good",

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -46,6 +46,10 @@ func (m mockQuerier) LabelNames() ([]string, error) {
 	return m.labelNames, m.labelNamesErr
 }
 
+func (m mockQuerier) LabelValues(string) ([]string, error) {
+	return nil, nil
+}
+
 func (m mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
 	panic("implement me")
 }

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -50,6 +50,9 @@ func (m mockQuerier) Select(int64, int64, bool, *storage.SelectHints, []parser.N
 	return &mockSeriesSet{}, nil, nil, m.err
 }
 
+func (m mockQuerier) LabelNames() ([]string, error) {
+	return nil, nil
+}
 func TestParseDuration(t *testing.T) {
 	testCase := []struct {
 		in          string
@@ -77,7 +80,7 @@ func TestParseDuration(t *testing.T) {
 	for _, tc := range testCase {
 		got, err := parseDuration(tc.in)
 		if err == nil && tc.expectError {
-			t.Errorf("unexected lack of error for input: %s", tc.in)
+			t.Errorf("unexpected lack of error for input: %s", tc.in)
 			continue
 		}
 		if err != nil && !tc.expectError {
@@ -171,8 +174,8 @@ func TestQuery(t *testing.T) {
 				},
 			)
 			handler := Query(engine, query.NewQueryable(tc.querier))
-			queryUrl := constructQuery(tc.metric, tc.time, tc.timeout)
-			w := doQuery(t, handler, queryUrl, tc.canceled)
+			queryURL := constructQuery(tc.metric, tc.time, tc.timeout)
+			w := doQuery(t, handler, queryURL, tc.canceled)
 
 			if w.Code != tc.expectCode {
 				t.Errorf("Unexpected HTTP status code received: got %d wanted %d", w.Code, tc.expectCode)

--- a/pkg/internal/testhelpers/PromTestDockerfile
+++ b/pkg/internal/testhelpers/PromTestDockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/prometheus.yml

--- a/pkg/internal/testhelpers/PromTestDockerfile
+++ b/pkg/internal/testhelpers/PromTestDockerfile
@@ -1,2 +1,0 @@
-FROM prom/prometheus
-ADD prometheus.yml /etc/prometheus/prometheus.yml

--- a/pkg/pgmodel/end_to_end_tests/main_test.go
+++ b/pkg/pgmodel/end_to_end_tests/main_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 
 func withDB(t testing.TB, DBName string, f func(db *pgxpool.Pool, t testing.TB)) {
 	testhelpers.WithDB(t, DBName, testhelpers.NoSuperuser, func(db *pgxpool.Pool, t testing.TB, connectURL string) {
-		performMigrate(t, DBName, connectURL)
+		performMigrate(t, connectURL)
 
 		//need to get a new pool after the Migrate to catch any GUC changes made during Migrate
 		db, err := pgxpool.Connect(context.Background(), connectURL)
@@ -101,7 +101,7 @@ func withDB(t testing.TB, DBName string, f func(db *pgxpool.Pool, t testing.TB))
 	})
 }
 
-func performMigrate(t testing.TB, DBName string, connectURL string) {
+func performMigrate(t testing.TB, connectURL string) {
 	dbStd, err := sql.Open("pgx", connectURL)
 	defer func() {
 		err := dbStd.Close()

--- a/pkg/pgmodel/end_to_end_tests/migrate_test.go
+++ b/pkg/pgmodel/end_to_end_tests/migrate_test.go
@@ -41,7 +41,7 @@ func TestMigrateTwice(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(db *pgxpool.Pool, t testing.TB, connectURL string) {
-		performMigrate(t, *testDatabase, connectURL)
-		performMigrate(t, *testDatabase, connectURL)
+		performMigrate(t, connectURL)
+		performMigrate(t, connectURL)
 	})
 }

--- a/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
@@ -428,6 +428,7 @@ func TestPromQLLabelEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not get label names from querier")
 		}
+		labelNames = append(labelNames, "unexisting_label")
 		for _, label := range labelNames {
 			req, err = getLabelValuesRequest(apiURL, label)
 			if err != nil {

--- a/pkg/pgmodel/end_to_end_tests/query_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/query_integration_test.go
@@ -948,8 +948,8 @@ func TestPromQL(t *testing.T) {
 
 func generateSamples(index int) []prompb.Sample {
 	var (
-		delta     float64 = float64(index * 2)
-		timeDelta int64   = 30000
+		delta           = float64(index * 2)
+		timeDelta int64 = 30000
 	)
 	samples := make([]prompb.Sample, 0, 3)
 	i := 0

--- a/pkg/pgmodel/pgx.go
+++ b/pkg/pgmodel/pgx.go
@@ -45,6 +45,7 @@ const (
 	finalizeMetricCreation          = "CALL " + catalogSchema + ".finalize_metric_creation()"
 	getSeriesIDForLabelSQL          = "SELECT * FROM " + catalogSchema + ".get_or_create_series_id_for_kv_array($1, $2, $3)"
 	getLabelNamesSQL                = "SELECT distinct key from " + catalogSchema + ".label"
+	getLabelValuesSQL               = "SELECT value from " + catalogSchema + ".label WHERE key = $1"
 )
 
 var (
@@ -929,7 +930,31 @@ func (q *pgxQuerier) LabelNames() ([]string, error) {
 	return labelNames, nil
 }
 
+func (q *pgxQuerier) LabelValues(labelName string) ([]string, error) {
+	rows, err := q.conn.Query(context.Background(), getLabelValuesSQL, labelName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	labelValues := make([]string, 0)
+
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			return nil, err
+		}
+
+		labelValues = append(labelValues, value)
+	}
+
+	sort.Strings(labelValues)
+	return labelValues, nil
+}
+
 func (q *pgxQuerier) getResultRows(startTimestamp int64, endTimestamp int64, hints *storage.SelectHints, path []parser.Node, matchers []*labels.Matcher) ([]pgx.Rows, parser.Node, error) {
+
 	metric, cases, values, err := buildSubQueries(matchers)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/pgmodel/pgx_test.go
+++ b/pkg/pgmodel/pgx_test.go
@@ -1192,6 +1192,18 @@ func TestPGXQuerierQuery(t *testing.T) {
 }
 
 func TestPgxQuerierLabelsNames(t *testing.T) {
+	testLabelMethods(t, func(querier *pgxQuerier) ([]string, error) {
+		return querier.LabelNames()
+	})
+}
+
+func TestPgxQuerierLabelsValues(t *testing.T) {
+	testLabelMethods(t, func(querier *pgxQuerier) ([]string, error) {
+		return querier.LabelValues("m")
+	})
+}
+
+func testLabelMethods(t *testing.T, f func(*pgxQuerier) ([]string, error)) {
 	testCases := []struct {
 		name         string
 		expectedRes  []string
@@ -1225,7 +1237,7 @@ func TestPgxQuerierLabelsNames(t *testing.T) {
 				QueryResults: queryResults,
 			}
 			querier := pgxQuerier{conn: mock}
-			res, err := querier.LabelNames()
+			res, err := f(&querier)
 			if tc.errorOnQuery && err == nil {
 				t.Error("unexpected lack of error")
 				return
@@ -1251,7 +1263,6 @@ func TestPgxQuerierLabelsNames(t *testing.T) {
 		})
 	}
 }
-
 func toRowResults(labelNames []string, convertImproperly bool) []rowResults {
 	toReturn := make([]rowResults, 1)
 	toReturn[0] = make(rowResults, len(labelNames))

--- a/pkg/pgmodel/querier.go
+++ b/pkg/pgmodel/querier.go
@@ -22,6 +22,7 @@ type Querier interface {
 	Query(*prompb.Query) ([]*prompb.TimeSeries, error)
 	Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error)
 	LabelNames() ([]string, error)
+	LabelValues(labelName string) ([]string, error)
 }
 
 //HealthChecker allows checking for proper operations.

--- a/pkg/pgmodel/querier.go
+++ b/pkg/pgmodel/querier.go
@@ -21,6 +21,7 @@ type Reader interface {
 type Querier interface {
 	Query(*prompb.Query) ([]*prompb.TimeSeries, error)
 	Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error)
+	LabelNames() ([]string, error)
 }
 
 //HealthChecker allows checking for proper operations.

--- a/pkg/pgmodel/querier_test.go
+++ b/pkg/pgmodel/querier_test.go
@@ -18,6 +18,8 @@ type mockQuerier struct {
 	tts               []*prompb.TimeSeries
 	err               error
 	healthCheckCalled bool
+	labelNames        []string
+	labelNamesErr     error
 }
 
 func (q *mockQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *storage.SelectHints, path []parser.Node, ms ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
@@ -26,6 +28,10 @@ func (q *mockQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *sto
 
 func (q *mockQuerier) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {
 	return q.tts, q.err
+}
+
+func (q *mockQuerier) LabelNames() ([]string, error) {
+	return q.labelNames, q.labelNamesErr
 }
 
 func (q *mockQuerier) HealthCheck() error {

--- a/pkg/pgmodel/querier_test.go
+++ b/pkg/pgmodel/querier_test.go
@@ -26,12 +26,16 @@ func (q *mockQuerier) Select(mint int64, maxt int64, sortSeries bool, hints *sto
 	return nil, nil, nil, nil
 }
 
-func (q *mockQuerier) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {
+func (q *mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
 	return q.tts, q.err
 }
 
 func (q *mockQuerier) LabelNames() ([]string, error) {
 	return q.labelNames, q.labelNamesErr
+}
+
+func (q *mockQuerier) LabelValues(string) ([]string, error) {
+	return nil, nil
 }
 
 func (q *mockQuerier) HealthCheck() error {

--- a/pkg/pgmodel/series_set_test.go
+++ b/pkg/pgmodel/series_set_test.go
@@ -160,7 +160,7 @@ func TestPgxSeriesSet(t *testing.T) {
 			name: "invalid label names",
 			input: append([][][][]byte{},
 				append([][][]byte{},
-					append([][]byte{[]byte{}},
+					append([][]byte{{}},
 						genSeries([]string{"one"}, nil, nil, nil)[1:4]...,
 					),
 				),

--- a/pkg/query/queryable.go
+++ b/pkg/query/queryable.go
@@ -39,8 +39,8 @@ func (q querier) LabelValues(name string) ([]string, storage.Warnings, error) {
 }
 
 func (q querier) LabelNames() ([]string, storage.Warnings, error) {
-	fmt.Println("querier label names")
-	return nil, nil, nil
+	lNames, err := q.pgQuerier.LabelNames()
+	return lNames, nil, err
 }
 
 func (q querier) Close() error {

--- a/pkg/query/queryable.go
+++ b/pkg/query/queryable.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
@@ -34,8 +32,8 @@ func newQuerier(ctx context.Context, q pgmodel.Querier, mint, maxt int64) (*quer
 }
 
 func (q querier) LabelValues(name string) ([]string, storage.Warnings, error) {
-	fmt.Println("querier label values: ", name)
-	return nil, nil, nil
+	lVals, err := q.pgQuerier.LabelValues(name)
+	return lVals, nil, err
 }
 
 func (q querier) LabelNames() ([]string, storage.Warnings, error) {


### PR DESCRIPTION
The LabelNames and LabelValues endpoints are required
so timescale-prometheus can be directly queried by Grafana.

Not all metadata endpoints are implemented as a
prometheus server has (the series  and metadata endpoints
are missing) but they are never queried by Grafana.

An http router is added to handle path params and scale
better than the default multiplexer under load