### PR TITLE
Fix pushdown array construction

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -130,7 +130,7 @@ pg_agg!{
 #[derive(Debug)]
 struct GapfillDeltaTransition {
     window: VecDeque<(TimestampTz, f64)>,
-    // all non-NULL values in the eventual array, length must be <= nulls.len()
+    // a Datum for each index in the array, 0 by convention if the value is NULL
     deltas: Vec<Datum>,
     // true if a given value in the array is null, length equal to the number of value
     nulls: Vec<bool>,
@@ -208,6 +208,7 @@ impl GapfillDeltaTransition {
     fn add_delta_for_current_window(&mut self) {
         if self.window.len() < 2 {
             // if there are 1 or fewer values in the window, store NULL
+            self.deltas.push(0);
             self.nulls.push(true);
             return
         }

--- a/pkg/pgmodel/end_to_end_tests/functions_test.go
+++ b/pkg/pgmodel/end_to_end_tests/functions_test.go
@@ -389,6 +389,16 @@ func TestExtensionGapfillDelta(t *testing.T) {
 		if res != "{200,-150}" {
 			t.Errorf("wrong result. Expected\n\t{200,-150}\nfound\n\t%s\n", res)
 		}
+
+		err = db.QueryRow(context.Background(),
+			"SELECT prom_delta('2000-01-02 14:15:00 UTC'::TIMESTAMPTZ, '2000-01-02 15:45:00 UTC'::TIMESTAMPTZ, 20 * 60 * 1000, 20 * 60 * 1000, t, v order by t)::TEXT FROM gfd_test_table;").Scan(&res)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "{NULL,NULL,200,-50}" {
+			t.Errorf("wrong result. Expected\n\t{NULL,NULL,200,-50}\nfound\n\t%s\n", res)
+		}
 	})
 }
 


### PR DESCRIPTION
Looks like we misunderstood construct_md_array, it needs to have an elem
for every slot in the array regardless of rather it's NULL (we had
thought it only needed non-NULL elements). This commit fixes this
oversight.