### PR TITLE
Add label cache, and only fetch missing labels at query time 

### DIFF
--- a/pkg/clockcache/cache.go
+++ b/pkg/clockcache/cache.go
@@ -36,9 +36,6 @@ type element struct {
 }
 
 func WithMax(max uint64) *Cache {
-	if max < 1 {
-		panic("must have max greater than 0")
-	}
 	return &Cache{
 		elements: make(map[interface{}]*element, max),
 		storage:  make([]element, 0, max),

--- a/pkg/pgmodel/end_to_end_tests/nan_test.go
+++ b/pkg/pgmodel/end_to_end_tests/nan_test.go
@@ -130,7 +130,7 @@ func TestSQLStaleNaN(t *testing.T) {
 		}
 
 		for _, c := range query {
-			r := NewPgxReader(db, nil)
+			r := NewPgxReader(db, nil, 100)
 			resp, err := r.Read(&c.rrq)
 			startMs := c.rrq.Queries[0].StartTimestampMs
 			endMs := c.rrq.Queries[0].EndTimestampMs

--- a/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
@@ -3,7 +3,6 @@ package end_to_end_tests
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/common/route"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/prometheus/common/route"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/prometheus/common/model"
@@ -347,7 +348,7 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 			return
 		}
 
-		r := pgmodel.NewPgxReader(readOnly, nil)
+		r := pgmodel.NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 		queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
 
@@ -401,7 +402,7 @@ func TestPromQLLabelEndpoints(t *testing.T) {
 			return
 		}
 
-		r := pgmodel.NewPgxReader(readOnly, nil)
+		r := pgmodel.NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 
 		labelNamesHandler := api.Labels(queryable)

--- a/pkg/pgmodel/end_to_end_tests/query_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/query_integration_test.go
@@ -534,7 +534,7 @@ func TestSQLQuery(t *testing.T) {
 			t.Fatalf("Cannot run test, not an instance of testing.T")
 		}
 
-		r := NewPgxReader(readOnly, nil)
+		r := NewPgxReader(readOnly, nil, 100)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
 				resp, err := r.Read(&c.readRequest)
@@ -915,7 +915,7 @@ func TestPromQL(t *testing.T) {
 			return
 		}
 
-		r := NewPgxReader(readOnly, nil)
+		r := NewPgxReader(readOnly, nil, 100)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
 				connResp, connErr := r.Read(c.readRequest)
@@ -1184,7 +1184,7 @@ func TestPushdown(t *testing.T) {
 			return
 		}
 
-		r := NewPgxReader(readOnly, nil)
+		r := NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 		queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
 

--- a/pkg/pgmodel/labels.go
+++ b/pkg/pgmodel/labels.go
@@ -161,13 +161,8 @@ func (l *Labels) Less(i, j int) bool {
 }
 
 func (l *Labels) Swap(i, j int) {
-	tmp := l.names[j]
-	l.names[j] = l.names[i]
-	l.names[i] = tmp
-
-	tmp = l.values[j]
-	l.values[j] = l.values[i]
-	l.values[i] = tmp
+	l.names[j], l.names[i] = l.names[i], l.names[j]
+	l.values[j], l.values[i] = l.values[i], l.values[j]
 }
 
 // FromLabelMatchers parses protobuf label matchers to Prometheus label matchers.


### PR DESCRIPTION
In simple queries, approximately 1/3rd our queries runtime is spent in
key_value_array. To reduce the time spent, this commit adds a cache of
ids-to-labels in the connector, so we can only fetch those labels we
have never seen before.