### PR TITLE
Add CLOCK based approximate LRU

### DIFF
--- a/pkg/clockcache/Readme.md
+++ b/pkg/clockcache/Readme.md
@@ -1,0 +1,72 @@
+# clockcache #
+
+This package contains a CLOCK based approximate-LRU cache optimized for
+concurrent usage. It minimizes both the number of locks held, and the number of
+writes to shared cache lines. In the worst case, this implementation requires
+_at most_ 1 shared-cache write on a hit, not counting lock acquisition.
+
+## Issues With Concurrent LRU ##
+
+Typically, LRU is implemented with a map and a doubly-linked list, all elements
+are stored in both the map, and the list. Whenever there's a hit on a
+cache-item, it's moved to the head of the list; evictions are done from the tail
+of the list. This ensures that it's always the least-recently-hit element that's
+evicted.
+
+While conceptually simple, the standard implementation of LRU as significant
+issues in a multi-processor setting, since _every_ read to the cache writes to
+the underlying datastructures. Updating the LRU list requires at least 4 writes
+on shared cache lines; 2 to unlink the element from it's old place in the list,
+and 2 more to add it to the head. When the LRU is being accessed from multiple
+cores, these cache lines will bounce among them, causing a significant slowdown.
+
+## CLOCK-based LRU ##
+
+The CLOCK algorithm approximates LRU. Conceptually, it augments a map with a
+bitset, with each element owning one bit in the bitset. Whenever an element is
+hit, it's bit is set to `1`. The evictor maintains a cursor into the bitset, and
+reads it round-robin.
+
+```
+                    eviction cursor
+                            v
+bitset: 0 1 0 0 1 1 0 1 0 0 1 1 1 1 0
+```
+
+Whenever the evictor sees a `1` it sets the bit to `0`.
+Whenever the evictor see a `0`, it evicts the element.
+This means that eviction always evicts an element that hasn't been read since
+the last time the evictor ran, and, since it reads the element in order, the
+first such element is the element that hasn't been touched the longest since the
+last run.
+
+### Concurrent CLOCK ###
+
+CLOCK two important benefits over regular LRU in a concurrent setting; the state
+that changes on a hit is per-element instead of shared, and the changes made by
+a hit are idempotent.
+
+Regular LRU relies on a shared list, which is manipulated every time an element
+is hit. CLOCK only requires a per-element bit to be set on a hit. This means
+that on a hit, only a single value, and with the proper layout, a single cache
+line, needs to be written to. Already, this reduces the worst-case number of
+writes to 1 from 4. We can further reduce the number of writes by observing that
+for an LRU to be useful, hits must be more common than evictions, and in CLOCK
+any successive hits before an eviction need not change any state; the bit is
+already set to `1`. This means that we can check the bit before writing it, and
+do nothing if it's already set, further reducing the number of writes.
+
+## Other Optimizations ##
+
+The map consists of a hashmap and slice. The map is used to perform key
+lookups, and the slice is used to ensure a consistent order for eviction checks.
+The actual elements and staleness-bits are stored in the slice, there is no
+separate bitset. Slice-elements nodes are padded to take a cache line
+each to prevent false-sharing. Staleness-bits are set using atomic operations,
+and are only written after they have been read to be `0`. The slice and map are
+preallocated to the maximum capacity of the cache, this prevents most
+allocations within the critical section (the map will occasionally allocate
+even with preallocation). We have separate locks for the slice and the cache;
+during eviction we grab a lock on only the slice, and allow gets to proceed
+until we find an element to evict. At that point we lock the map and replace the
+element.

--- a/pkg/clockcache/cache.go
+++ b/pkg/clockcache/cache.go
@@ -1,0 +1,288 @@
+package clockcache
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// CLOCK based approximate LRU storing designed for concurrent usage.
+// Gets only require a read lock, while Inserts take at least one write lock.
+type Cache struct {
+	// guards elements and all fields except for `used` in Element, must have at
+	// least a read-lock to access, and a write-lock to insert/update/delete.
+	elementsLock sync.RWMutex
+	// stores indexes into storage
+	elements map[interface{}]*element
+	storage  []element
+
+	// guards next, and len(storage) and ensures that at most one eviction
+	// occurs at a time, always grabbed _before_ elementsLock
+	insertLock sync.Mutex
+	// CLOCK sweep state, must have the insertLock
+	next int
+}
+
+type element struct {
+	// The value stored with this element.
+	key   interface{}
+	value interface{}
+
+	// CLOCK marker if this is recently used
+	used uint32
+
+	// pad Elements out to be cache aligned
+	_ [24]byte
+}
+
+func WithMax(max uint64) *Cache {
+	if max < 1 {
+		panic("must have max greater than 0")
+	}
+	return &Cache{
+		elements: make(map[interface{}]*element, max),
+		storage:  make([]element, 0, max),
+	}
+}
+
+// Insert a key/value mapping into the cache if the key is not already present
+// returns the canonical version of the value
+// and if the value is in the map
+func (self *Cache) Insert(key interface{}, value interface{}) (canonicalValue interface{}, in_cache bool) {
+	self.insertLock.Lock()
+	defer self.insertLock.Unlock()
+
+	_, canonicalValue, in_cache = self.insert(key, value)
+	return
+}
+
+// Insert a batch of keys with their corresponding values.
+// This function will _overwrite_ the keys and values slices with their
+// canonical versions.
+// returns the number of elements inserted, is lower than len(keys) if insertion
+// starved
+func (self *Cache) InsertBatch(keys []interface{}, values []interface{}) int {
+	if len(keys) != len(values) {
+		panic(fmt.Sprintf("keys and values are not the same len. %d keys, %d values", len(keys), len(values)))
+	}
+	values = values[:len(keys)]
+	self.insertLock.Lock()
+	defer self.insertLock.Unlock()
+
+	for idx := range keys {
+		var inserted bool
+		keys[idx], values[idx], inserted = self.insert(keys[idx], values[idx])
+		if !inserted {
+			return idx
+		}
+	}
+	return len(keys)
+}
+
+func (self *Cache) insert(key interface{}, value interface{}) (canonicalKey interface{}, canonicalValue interface{}, inserted bool) {
+	elem, present := self.elements[key]
+	if present {
+		// we'll count a double-insert as a hit. See the comment in get
+		if atomic.LoadUint32(&elem.used) != 0 {
+			atomic.StoreUint32(&elem.used, 1)
+		}
+		return elem.key, elem.value, true
+	}
+
+	var insertLocation *element
+	if len(self.storage) >= cap(self.storage) {
+		insertLocation = self.evict()
+		if insertLocation == nil {
+			return key, value, false
+		}
+		self.elementsLock.Lock()
+		defer self.elementsLock.Unlock()
+		delete(self.elements, insertLocation.key)
+		*insertLocation = element{key: key, value: value}
+	} else {
+		self.elementsLock.Lock()
+		defer self.elementsLock.Unlock()
+		self.storage = append(self.storage, element{key: key, value: value})
+		insertLocation = &self.storage[len(self.storage)-1]
+	}
+
+	self.elements[key] = insertLocation
+	return key, value, true
+}
+
+func (self *Cache) evict() (insertPtr *element) {
+	// this code goes around storage in a ring searching for the first element
+	// not marked as used, which it will evict. The code has two unusual
+	// features:
+	//  1. it will go through storage at most twice before giving up. Concurrent
+	//     gets can starve out the evictor, in which case the cache is too small
+	//  2. it divides the walk through storage into two loops, one walk through
+	//     all the elements after the last place the evictor stopped, one
+	//     through all elements before that location. This is due to a limitation
+	//     in go's bounds check elimination, where it will only eliminate checks
+	//     based off an induction variable e.g. `next := range slice`,
+	//     if the value is merely guarded by e.g. `if next >= len(slice) { next = 0 }`
+	//     the bounds check will not be elided. Doing the walk like this lowers
+	//     eviction time by about a third
+	startLoc := self.next
+	postStart := self.storage[startLoc:]
+	preStart := self.storage[:startLoc]
+	for i := 0; i < 2; i++ {
+		for next := range postStart {
+			elem := &postStart[next]
+			old := atomic.SwapUint32(&elem.used, 0)
+			if old == 0 {
+				insertPtr = elem
+			}
+
+			if insertPtr != nil {
+				self.next = next + 1
+				return
+			}
+		}
+		for next := range preStart {
+			elem := &preStart[next]
+			old := atomic.SwapUint32(&elem.used, 0)
+			if old == 0 {
+				insertPtr = elem
+			}
+
+			if insertPtr != nil {
+				self.next = next + 1
+				return
+			}
+		}
+	}
+
+	return
+}
+
+// tries to get a batch of keys and store the corresponding values is valuesOut
+// returns the number of keys that were actually found.
+// NOTE: this function does _not_ preserve the order of keys; the first numFound
+//       keys will be the keys whose values are present, while the remainder
+//       will be the keys not present in the cache
+func (self *Cache) GetValues(keys []interface{}, valuesOut []interface{}) (numFound int) {
+	if len(keys) != len(valuesOut) {
+		panic(fmt.Sprintf("keys and values are not the same len. %d keys, %d values", len(keys), len(valuesOut)))
+	}
+	valuesOut = valuesOut[:len(keys)]
+	n := len(keys)
+	idx := 0
+
+	self.elementsLock.RLock()
+	defer self.elementsLock.RUnlock()
+
+	for idx < n {
+		value, found := self.get(keys[idx])
+		if !found {
+			if n == 0 {
+				return 0
+			}
+			// no value found for key, swap the key with the last element, and shrink n
+			n -= 1
+			keys[n], keys[idx] = keys[idx], keys[n]
+			continue
+		}
+		valuesOut[idx] = value
+		idx += 1
+	}
+	return n
+}
+
+func (self *Cache) Get(key interface{}) (interface{}, bool) {
+	self.elementsLock.RLock()
+	defer self.elementsLock.RUnlock()
+	return self.get(key)
+}
+
+func (self *Cache) get(key interface{}) (interface{}, bool) {
+
+	elem, present := self.elements[key]
+	if !present {
+		return 0, false
+	}
+
+	// While logically this is a CompareAndSwap, this code has an important
+	// advantage: in the common case of the element already being marked as used,
+	// this is a read-only operation, and doesn't trash the cache line that used
+	// is stored on. The lack of atomicity of the update doesn't matter for our
+	// use case.
+	if atomic.LoadUint32(&elem.used) == 0 {
+		atomic.StoreUint32(&elem.used, 1)
+	}
+
+	return elem.value, true
+}
+
+func (self *Cache) unmark(key string) bool {
+	self.elementsLock.RLock()
+	defer self.elementsLock.RUnlock()
+
+	elem, present := self.elements[key]
+	if !present {
+		return false
+	}
+
+	// While logically this is a CompareAndSwap, this code has an important
+	// advantage: in the common case of the element already being marked as used,
+	// this is a read-only operation, and doesn't trash the cache line that used
+	// is stored on. The lack of atomicity of the update doesn't matter for our
+	// use case.
+	if atomic.LoadUint32(&elem.used) != 0 {
+		atomic.StoreUint32(&elem.used, 0)
+	}
+
+	return true
+}
+
+func (self *Cache) ExpandTo(newMax int) {
+	self.insertLock.Lock()
+	defer self.insertLock.Unlock()
+
+	oldMax := cap(self.storage)
+	if newMax <= oldMax {
+		return
+	}
+
+	newStorage := make([]element, 0, newMax)
+
+	// cannot use copy here despite the data race on element.used
+	for i := range self.storage {
+		elem := &self.storage[i]
+		newStorage = append(newStorage, element{
+			key:   elem.key,
+			value: elem.value,
+			used:  atomic.LoadUint32(&elem.used),
+		})
+	}
+
+	newElements := make(map[interface{}]*element, newMax)
+	for i := range newStorage {
+		elem := &newStorage[i]
+		newElements[elem.key] = elem
+	}
+
+	self.elementsLock.Lock()
+	defer self.elementsLock.Unlock()
+
+	self.elements = newElements
+	self.storage = newStorage
+}
+
+func (self *Cache) Len() int {
+	self.elementsLock.RLock()
+	defer self.elementsLock.RUnlock()
+	return len(self.storage)
+}
+
+func (self *Cache) debugString() string {
+	self.elementsLock.RLock()
+	defer self.elementsLock.RUnlock()
+	str := "["
+	for i := range self.storage {
+		elem := &self.storage[i]
+		str = fmt.Sprintf("%s%v: %v, ", str, elem.key, elem.value)
+	}
+	return fmt.Sprintf("%s]", str)
+}

--- a/pkg/clockcache/cache_bench_test.go
+++ b/pkg/clockcache/cache_bench_test.go
@@ -1,0 +1,235 @@
+package clockcache
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// microbenchmark. measure the length of the Insert critical section
+func BenchmarkIntCache(b *testing.B) {
+	keys := make([]interface{}, b.N)
+	for i := range keys {
+		keys[i] = i
+	}
+	cache := WithMax(uint64(b.N))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Insert(keys[i], keys[i])
+	}
+}
+
+// microbenchmark. measure the length of the Insert critical section
+func BenchmarkStringCache(b *testing.B) {
+	keys := make([]interface{}, b.N)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key-%d", i)
+	}
+	cache := WithMax(uint64(b.N))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Insert(keys[i], keys[i])
+	}
+}
+
+// microbenchmark. measure the time it takes to evict on a fully-used cache.
+// attempts to measure worst-cache eviction time, but under-measures contention.
+func BenchmarkEviction(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+			insertKeys := make([]interface{}, b.N)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = n, n
+			}
+			rand.Shuffle(len(keys), func(i, j int) {
+				keys[i], keys[j] = keys[j], keys[i]
+			})
+
+			for i := 0; i < b.N; i++ {
+				insertKeys[i] = b.N + i
+			}
+			rand.Shuffle(len(insertKeys), func(i, j int) {
+				insertKeys[i], insertKeys[j] = insertKeys[j], insertKeys[i]
+			})
+
+			cache := WithMax(uint64(n / 4))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				bval, _ = cache.Insert(insertKeys[i%n], insertKeys[i%n])
+				cache.markAll()
+			}
+		})
+	}
+}
+
+func (c *Cache) markAll() {
+	for i := range c.storage {
+		c.storage[i].used = 2
+	}
+}
+
+// microbenchmark. attempts to measure a cache hit
+func BenchmarkMembership(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000, 500000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(299792458))
+
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = i, i
+			}
+
+			rng.Shuffle(len(keys), func(i, j int) {
+				keys[i], keys[j] = keys[j], keys[i]
+			})
+
+			cache := WithMax(uint64(n))
+			cache.InsertBatch(keys, vals)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				bval, _ = cache.Get(keys[i%n])
+			}
+		})
+	}
+}
+
+// microbenchmark. attempts to measure a cache miss
+func BenchmarkNotFound(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000, 500000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(299792458))
+
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+			gets := make([]interface{}, n)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = i, i
+				gets[i] = n + i
+			}
+
+			rng.Shuffle(len(keys), func(i, j int) {
+				keys[i], keys[j] = keys[j], keys[i]
+			})
+
+			cache := WithMax(uint64(n))
+			cache.InsertBatch(keys, vals)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				bval, _ = cache.Get(gets[i%n])
+			}
+		})
+	}
+}
+
+// more macro benchmarks
+
+var bval interface{}
+
+func BenchmarkInsertUnderCapacity(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000, 500000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(299792458))
+			zipf := rand.NewZipf(rng, 1.07, 1, 1e9)
+
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = zipf.Uint64(), rng.Intn(1e9)
+			}
+
+			cache := WithMax(uint64(n))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			inserts := 0
+			var inserted bool
+			for i := 0; i < b.N; i++ {
+				bval, inserted = cache.Insert(keys[i%n], vals[i%n])
+				if inserted {
+					inserts++
+				}
+				b.ReportMetric(float64(inserts), "inserts")
+				b.ReportMetric(float64(inserts)/float64(b.N), "inserts/ops")
+			}
+		})
+	}
+}
+
+func BenchmarkInsertOverCapacity(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000, 500000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(299792458))
+			zipf := rand.NewZipf(rng, 1.07, 1, 1e9)
+
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = zipf.Uint64(), rng.Intn(1e9)
+			}
+
+			cache := WithMax(uint64(n / 4))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			inserts := 0
+			var inserted bool
+			for i := 0; i < b.N; i++ {
+				bval, inserted = cache.Insert(keys[i%n], vals[i%n])
+				if inserted {
+					cache.Get(keys[i%n])
+					inserts++
+				}
+			}
+			b.ReportMetric(float64(inserts), "inserts")
+			b.ReportMetric(float64(inserts)/float64(b.N), "inserts/ops")
+		})
+	}
+}
+
+func BenchmarkInsertConcurrent(b *testing.B) {
+	for _, n := range []int{500, 5000, 50000, 500000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(299792458))
+			zipf := rand.NewZipf(rng, 1.07, 1, 1e9)
+
+			keys := make([]interface{}, n)
+			vals := make([]interface{}, n)
+
+			for i := 0; i < n; i++ {
+				keys[i], vals[i] = zipf.Uint64(), rng.Intn(1e9)
+			}
+
+			cache := WithMax(uint64(n / 4))
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				var val interface{}
+				i := 0
+				for pb.Next() {
+					val, _ = cache.Insert(keys[i%n], vals[i%n])
+					cache.Get(keys[i%n])
+					i++
+				}
+				bval = val
+			})
+		})
+	}
+}

--- a/pkg/clockcache/cache_test.go
+++ b/pkg/clockcache/cache_test.go
@@ -1,0 +1,208 @@
+package clockcache
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+func TestWriteAndGetOnCache(t *testing.T) {
+	t.Parallel()
+
+	cache := WithMax(100)
+
+	cache.Insert("1", 1)
+	val, found := cache.Get("1")
+
+	// then
+	if !found {
+		t.Error("no value found")
+	}
+	if val != 1 {
+		t.Errorf("expected %d found %d", 1, val)
+	}
+}
+
+func TestEntryNotFound(t *testing.T) {
+	t.Parallel()
+
+	cache := WithMax(100)
+
+	val, found := cache.Get("nonExistingKey")
+	if found {
+		t.Errorf("found %d for noexistent key", val)
+	}
+
+	cache.Insert("key", 1)
+
+	val, found = cache.Get("nonExistingKey")
+	if found {
+		t.Errorf("found %d for noexistent key", val)
+	}
+}
+
+func TestEviction(t *testing.T) {
+	t.Parallel()
+
+	cache := WithMax(10)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%d", i)
+		cache.Insert(key, int64(i))
+		if i != 5 {
+			cache.Get(key)
+		}
+	}
+
+	cache.Insert("100", 100)
+	cache.Get("100")
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%d", i)
+		val, found := cache.Get(key)
+		if i != 5 && (!found || val != int64(i)) {
+			t.Errorf("missing value %d, got %d", i, val)
+		} else if i == 5 && found {
+			t.Errorf("5 not evicted")
+		}
+		if i == 2 {
+			cache.unmark(key)
+		}
+	}
+
+	val, found := cache.Get("100")
+	if !found || val != 100 {
+		t.Errorf("missing value 100, got %d", val)
+	}
+
+	cache.Insert("101", 101)
+	cache.Get("101")
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%d", i)
+		val, found := cache.Get(key)
+		if i != 5 && i != 2 && (!found || val != int64(i)) {
+			t.Errorf("missing value %d, (found: %v) got %d", i, found, val)
+		} else if (i == 5 || i == 2) && found {
+			t.Errorf("%d not evicted", i)
+		}
+	}
+
+	val, found = cache.Get("100")
+	if !found || val != 100 {
+		t.Errorf("missing value 100, got %d", val)
+	}
+	val, found = cache.Get("101")
+	if !found || val != 101 {
+		t.Errorf("missing value 101, got %d", val)
+	}
+}
+
+func TestCacheGetRandomly(t *testing.T) {
+	t.Parallel()
+
+	cache := WithMax(10000)
+	var wg sync.WaitGroup
+	var ntest = 800000
+	wg.Add(2)
+	go func() {
+		for i := 0; i < ntest; i++ {
+			r := rand.Int63() % 20000
+			key := fmt.Sprintf("%d", r)
+			cache.Insert(key, r+1)
+		}
+		wg.Done()
+	}()
+	go func() {
+		for i := 0; i < ntest; i++ {
+			r := rand.Int63()
+			key := fmt.Sprintf("%d", r)
+			if val, found := cache.Get(key); found && val != r+1 {
+				t.Errorf("got %s ->\n %x\n expected:\n %x\n ", key, val, r+1)
+			}
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestBatch(t *testing.T) {
+	t.Parallel()
+
+	cache := WithMax(10)
+
+	cache.InsertBatch([]interface{}{3, 6, 9, 12}, []interface{}{4, 7, 10, 13})
+
+	keys := []interface{}{1, 2, 3, 6, 9, 12, 13}
+	vals := make([]interface{}, len(keys))
+	numFound := cache.GetValues(keys, vals)
+
+	if numFound != 4 {
+		t.Errorf("found incorrect number of values: expected 4, found %d\n\tkeys: %v\n\t%v", numFound, keys, vals)
+	}
+
+	expectedKeys := []interface{}{12, 9, 3, 6, 2, 13, 1}
+	if !reflect.DeepEqual(keys, expectedKeys) {
+		t.Errorf("unexpected keys:\nexpected\n\t%v\nfound\n\t%v", keys, expectedKeys)
+	}
+
+	expectedVals := []interface{}{13, 10, 4, 7, nil, nil, nil}
+	if !reflect.DeepEqual(vals, expectedVals) {
+		t.Errorf("unexpected values:\nexpected\n\t%v\nfound\n\t%v", expectedVals, vals)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	cache := WithMax(3)
+	cache.Insert(1, 1)
+	cache.Get(1)
+
+	cache.Insert(2, 2)
+
+	cache.Insert(3, 3)
+	cache.Get(3)
+
+	expected := "[1: 1, 2: 2, 3: 3, ]"
+	if cache.debugString() != expected {
+		t.Errorf("unexpected cache\nexpected\n\t%s\nfound\n\t%s\n", expected, cache.debugString())
+	}
+
+	cache.Insert(4, 4)
+	expected = "[1: 1, 4: 4, 3: 3, ]"
+	if cache.debugString() != expected {
+		t.Errorf("unexpected cache\nexpected\n\t%s\nfound\n\t%s\n", expected, cache.debugString())
+	}
+
+	cache.ExpandTo(5)
+	expected = "[1: 1, 4: 4, 3: 3, ]"
+	if cache.debugString() != expected {
+		t.Errorf("unexpected cache\nexpected\n\t%s\nfound\n\t%s\n", expected, cache.debugString())
+	}
+
+	cache.Insert(5, 5)
+	cache.Get(5)
+
+	cache.Insert(6, 6)
+	expected = "[1: 1, 4: 4, 3: 3, 5: 5, 6: 6, ]"
+	if cache.debugString() != expected {
+		t.Errorf("unexpected cache\nexpected\n\t%s\nfound\n\t%s\n", expected, cache.debugString())
+	}
+
+	cache.Insert(7, 7)
+	expected = "[1: 1, 4: 4, 3: 3, 5: 5, 7: 7, ]"
+	if cache.debugString() != expected {
+		t.Errorf("unexpected cache\nexpected\n\t%s\nfound\n\t%s\n", expected, cache.debugString())
+	}
+}
+
+func TestElementCacheAligned(t *testing.T) {
+	elementSize := unsafe.Sizeof(element{})
+	if elementSize%64 != 0 {
+		t.Errorf("unaligned element size: %d", elementSize)
+	}
+	if elementSize != 64 {
+		t.Errorf("unexpected element size: %d", elementSize)
+	}
+}


### PR DESCRIPTION
We have a number of places in the connector where we want to store a
cache of elements. Our expectation is that the set of live elements
will be time-correlated, and therefore, when we want to evict elements
from the cache the least-recently-used element is the one least likely
to be used again in the future. There for this commit adds an LRU
implementation suitable for use in such caches. Traditional LRUs suffer
from large amounts of contention in multi-threaded workloads, so we use
a CLOCK-based approximate LRU; more information can be found in the
README.