### PR TITLE
Add proper CORS handling by the HTTP API

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestCORSWrapper(t *testing.T) {
+	_ = log.Init("debug")
+	acceptSpecific, _ := regexp.Compile("^(?:" + "http://some-site.com" + ")$")
+	acceptAny, _ := regexp.Compile("^(?:" + ".*" + ")$")
+
+	testCases := []struct {
+		name           string
+		requestOrigin  string
+		acceptedOrigin *regexp.Regexp
+		expectHeaders  map[string][]string
+	}{
+		{
+			name:           "No origin",
+			requestOrigin:  "",
+			acceptedOrigin: acceptSpecific,
+			expectHeaders:  map[string][]string{},
+		}, {
+			name:           "Origin doesn't match accepted",
+			requestOrigin:  "http://some-unknown-site.com",
+			acceptedOrigin: acceptSpecific,
+			expectHeaders: map[string][]string{
+				"Access-Control-Allow-Headers":  {"Accept, Authorization, Content-Type, Origin"},
+				"Access-Control-Allow-Methods":  {"GET, POST, OPTIONS"},
+				"Access-Control-Expose-Headers": {"Date"},
+				"Vary":                          {"Origin"},
+			},
+		},
+		{
+			name:           "Origin matches accepted",
+			requestOrigin:  "http://some-site.com",
+			acceptedOrigin: acceptSpecific,
+			expectHeaders: map[string][]string{
+				"Access-Control-Allow-Headers":  {"Accept, Authorization, Content-Type, Origin"},
+				"Access-Control-Allow-Methods":  {"GET, POST, OPTIONS"},
+				"Access-Control-Expose-Headers": {"Date"},
+				"Access-Control-Allow-Origin":   {"http://some-site.com"},
+				"Vary":                          {"Origin"},
+			},
+		}, {
+			name:           "Wildcard allowed origin",
+			requestOrigin:  "http://any-site.com",
+			acceptedOrigin: acceptAny,
+			expectHeaders: map[string][]string{
+				"Access-Control-Allow-Headers":  {"Accept, Authorization, Content-Type, Origin"},
+				"Access-Control-Allow-Methods":  {"GET, POST, OPTIONS"},
+				"Access-Control-Expose-Headers": {"Date"},
+				"Access-Control-Allow-Origin":   {"*"},
+				"Vary":                          {"Origin"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &Config{}
+			if tc.acceptedOrigin != nil {
+				conf.AllowedOrigin = tc.acceptedOrigin
+			} else {
+				tc.acceptedOrigin = &regexp.Regexp{}
+			}
+			internalHandlerCalled := false
+			handler := corsWrapper(conf, func(http.ResponseWriter, *http.Request) {
+				internalHandlerCalled = true
+			})
+			w := doCORSWrapperRequest(t, handler, "http://localhost/", tc.requestOrigin)
+			if !internalHandlerCalled {
+				t.Fatalf("internal handler not called by CORS wrapper")
+				return
+			}
+			returnedHeaders := w.Header()
+			if len(returnedHeaders) != len(tc.expectHeaders) {
+				t.Fatalf("expected %d headers, got %d", len(tc.expectHeaders), len(returnedHeaders))
+				return
+			}
+			for hName, hValues := range tc.expectHeaders {
+				returnedValues := returnedHeaders[hName]
+				if !reflect.DeepEqual(hValues, returnedValues) {
+					t.Errorf("expected header %s with value %v; got %v", hName, hValues, returnedValues)
+				}
+			}
+		})
+
+	}
+
+}
+
+func doCORSWrapperRequest(t *testing.T, queryHandler http.Handler, url, origin string) *httptest.ResponseRecorder {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	req.Header.Set("Origin", origin)
+	w := httptest.NewRecorder()
+	queryHandler.ServeHTTP(w, req)
+	return w
+}

--- a/pkg/api/labels_test.go
+++ b/pkg/api/labels_test.go
@@ -35,7 +35,7 @@ func TestLabels(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := Labels(query.NewQueryable(tc.querier))
+			handler := labelsHandler(query.NewQueryable(tc.querier))
 			w := doLabels(t, handler)
 
 			if w.Code != tc.expectCode {

--- a/pkg/api/query_range.go
+++ b/pkg/api/query_range.go
@@ -11,8 +11,13 @@ import (
 	"github.com/timescale/timescale-prometheus/pkg/query"
 )
 
-func QueryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.Handler {
-	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func QueryRange(conf *Config, queryEngine *promql.Engine, queriable *query.Queryable) http.Handler {
+	hf := corsWrapper(conf, queryRange(queryEngine, queriable))
+	return gziphandler.GzipHandler(hf)
+}
+
+func queryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		start, err := parseTime(r.FormValue("start"))
 		if err != nil {
 			log.Info("msg", "Query bad request:"+err.Error())
@@ -101,7 +106,5 @@ func QueryRange(queryEngine *promql.Engine, queriable *query.Queryable) http.Han
 		}
 
 		respondQuery(w, res, res.Warnings)
-	})
-
-	return gziphandler.GzipHandler(hf)
+	}
 }

--- a/pkg/api/query_range_test.go
+++ b/pkg/api/query_range_test.go
@@ -154,7 +154,7 @@ func TestRangedQuery(t *testing.T) {
 					Timeout:    timeout,
 				},
 			)
-			handler := QueryRange(engine, query.NewQueryable(tc.querier))
+			handler := queryRange(engine, query.NewQueryable(tc.querier))
 			queryUrl := constructRangedQuery(tc.metric, tc.start, tc.end, tc.step, tc.timeout)
 			w := doRangedQuery(t, handler, queryUrl, tc.canceled)
 

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/timescale/timescale-prometheus/pkg/log"
@@ -59,7 +59,6 @@ func (m mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
 
 func (m mockQuerier) Select(int64, int64, bool, *storage.SelectHints, []parser.Node, ...*labels.Matcher) (storage.SeriesSet, parser.Node, storage.Warnings, error) {
 	time.Sleep(m.timeToSleepOnSelect)
-
 	return &mockSeriesSet{}, nil, nil, m.selectErr
 }
 
@@ -191,7 +190,7 @@ func TestQuery(t *testing.T) {
 					Timeout:    timeout,
 				},
 			)
-			handler := Query(engine, query.NewQueryable(tc.querier))
+			handler := queryHandler(engine, query.NewQueryable(tc.querier))
 			queryURL := constructQuery(tc.metric, tc.time, tc.timeout)
 			w := doQuery(t, handler, queryURL, tc.canceled)
 

--- a/pkg/api/read.go
+++ b/pkg/api/read.go
@@ -12,7 +12,6 @@ import (
 )
 
 func Read(reader pgmodel.Reader, metrics *Metrics) http.Handler {
-	log.Init("debug")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		compressed, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/pkg/api/series_test.go
+++ b/pkg/api/series_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestSeries(t *testing.T) {
 	_ = log.Init("debug")
+
 	testCases := []struct {
 		name        string
 		querier     *mockQuerier
@@ -82,7 +83,7 @@ func TestSeries(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := Series(query.NewQueryable(tc.querier))
+			handler := series(query.NewQueryable(tc.querier))
 			queryUrl := constructSeriesRequest(tc.start, tc.end, tc.matchers)
 			w := doSeriesRequest(t, handler, queryUrl)
 
@@ -95,7 +96,6 @@ func TestSeries(t *testing.T) {
 				_ = json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&er)
 				if tc.expectError != er.ErrorType {
 					t.Errorf("expected error of type %s, got %s", tc.expectError, er.ErrorType)
-					return
 				}
 			}
 		})

--- a/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/promql_endpoint_integration_test.go
@@ -390,9 +390,9 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 		r := pgmodel.NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 		queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
-
-		instantQuery := api.Query(queryEngine, queryable)
-		rangeQuery := api.QueryRange(queryEngine, queryable)
+		apiConfig := &api.Config{}
+		instantQuery := api.Query(apiConfig, queryEngine, queryable)
+		rangeQuery := api.QueryRange(apiConfig, queryEngine, queryable)
 
 		apiURL := fmt.Sprintf("http://%s:%d/api/v1", testhelpers.PromHost, testhelpers.PromPort.Int())
 		client := &http.Client{Timeout: 10 * time.Second}
@@ -489,7 +489,7 @@ func TestPromQLSeriesEndpoint(t *testing.T) {
 		r := pgmodel.NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 
-		series := api.Series(queryable)
+		series := api.Series(&api.Config{}, queryable)
 
 		apiURL := fmt.Sprintf("http://%s:%d/api/v1", testhelpers.PromHost, testhelpers.PromPort.Int())
 		client := &http.Client{Timeout: 10 * time.Second}
@@ -539,8 +539,9 @@ func TestPromQLLabelEndpoints(t *testing.T) {
 		r := pgmodel.NewPgxReader(readOnly, nil, 100)
 		queryable := query.NewQueryable(r.GetQuerier())
 
-		labelNamesHandler := api.Labels(queryable)
-		labelValuesHandler := api.LabelValues(queryable)
+		apiConfig := &api.Config{}
+		labelNamesHandler := api.Labels(apiConfig, queryable)
+		labelValuesHandler := api.LabelValues(apiConfig, queryable)
 		router := route.New()
 		router.Get("/api/v1/label/:name/values", labelValuesHandler.ServeHTTP)
 		router.Get("/api/v1/labels", labelNamesHandler.ServeHTTP)


### PR DESCRIPTION
A flag can be set by the user to specify the allowed
origins to access the HTTP API. A wrapper handler
sets the proper CORS headers if the flag is enabled.