### PR TITLE
Reenable the WriteRequest pool, fixing data corruption

### DIFF
--- a/pkg/pgmodel/end_to_end_tests/concurrent_sql_test.go
+++ b/pkg/pgmodel/end_to_end_tests/concurrent_sql_test.go
@@ -225,7 +225,7 @@ func testConcurrentInsertSimple(t testing.TB, db *pgxpool.Pool, metric string) {
 		t.Fatal(err)
 	}
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(metrics, NewWriteRequest())
+	_, err = ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func testConcurrentInsertAdvanced(t testing.TB, db *pgxpool.Pool) {
 	}
 
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(metrics, NewWriteRequest())
+	_, err = ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pgmodel/end_to_end_tests/create_test.go
+++ b/pkg/pgmodel/end_to_end_tests/create_test.go
@@ -160,7 +160,7 @@ func TestSQLChunkInterval(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -401,7 +401,7 @@ func TestSQLIngest(t *testing.T) {
 				}
 				defer ingestor.Close()
 
-				cnt, err := ingestor.Ingest(tcase.metrics, NewWriteRequest())
+				cnt, err := ingestor.Ingest(copyMetrics(tcase.metrics), NewWriteRequest())
 				if err != nil && err != tcase.expectErr {
 					t.Fatalf("got an unexpected error %v", err)
 				}
@@ -479,7 +479,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -510,7 +510,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 			},
 		}
 
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -535,7 +535,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 		}
 
 		//ingest duplicate after compression
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -582,7 +582,7 @@ func TestInsertCompressed(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -600,7 +600,7 @@ func TestInsertCompressed(t *testing.T) {
 			}
 		}
 		//ingest after compression
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -613,4 +613,16 @@ func TestInsertCompressed(t *testing.T) {
 			t.Error("next_start was not changed enough")
 		}
 	})
+}
+
+// deep copy the metrics since we mutate them, and don't want to invalidate the tests
+func copyMetrics(metrics []prompb.TimeSeries) []prompb.TimeSeries {
+	out := make([]prompb.TimeSeries, len(metrics))
+	copy(out, metrics)
+	for i := range out {
+		samples := make([]prompb.Sample, len(out[i].Samples))
+		copy(samples, out[i].Samples)
+		out[i].Samples = samples
+	}
+	return out
 }

--- a/pkg/pgmodel/end_to_end_tests/drop_test.go
+++ b/pkg/pgmodel/end_to_end_tests/drop_test.go
@@ -49,7 +49,7 @@ func TestSQLRetentionPeriod(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestSQLDropChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -233,7 +233,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 		}
 
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(ts, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(ts), NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/pgmodel/end_to_end_tests/nan_test.go
+++ b/pkg/pgmodel/end_to_end_tests/nan_test.go
@@ -73,7 +73,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 
 		if err != nil {
 			t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/pgmodel/end_to_end_tests/query_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/query_integration_test.go
@@ -565,7 +565,7 @@ func ingestQueryTestDataset(db *pgxpool.Pool, t testing.TB, metrics []prompb.Tim
 	if err != nil {
 		t.Fatal(err)
 	}
-	cnt, err := ingestor.Ingest(metrics, NewWriteRequest())
+	cnt, err := ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 
 	if err != nil {
 		t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/pgmodel/end_to_end_tests/view_test.go
+++ b/pkg/pgmodel/end_to_end_tests/view_test.go
@@ -150,7 +150,7 @@ func TestSQLView(t *testing.T) {
 		}
 
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)
@@ -248,7 +248,7 @@ func TestSQLViewSelectors(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(metrics, NewWriteRequest())
+		_, err = ingestor.Ingest(copyMetrics(metrics), NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/pgmodel/ingestor.go
+++ b/pkg/pgmodel/ingestor.go
@@ -76,7 +76,8 @@ func (i *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.WriteRequest
 	dataSamples := make(map[string][]samplesInfo)
 	rows := 0
 
-	for _, t := range tts {
+	for i := range tts {
+		t := &tts[i]
 		if len(t.Samples) == 0 {
 			continue
 		}


### PR DESCRIPTION
Fix a bug in the ingestor which could cause data corruption as samples were readded to the WriteReq pool before they were written to the DB. With this commit we can re-enable the pool. Actually using the pool gives a 10% speedup.