### PR TITLE
Fix for min/max start/end timestamp values for remote read

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -2,16 +2,18 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/storage"
-	"github.com/timescale/timescale-prometheus/pkg/promql"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/timescale/timescale-prometheus/pkg/promql"
 )
 
 var (
@@ -99,6 +101,18 @@ func marshalMatrixResponse(writer io.Writer, data promql.Matrix, warnings []stri
 	marshalMatrixData(out, data)
 	marshalCommonFooter(out, warnings)
 	return out.err
+}
+
+func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (time.Time, error) {
+	val := r.FormValue(paramName)
+	if val == "" {
+		return defaultValue, nil
+	}
+	result, err := parseTime(val)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("Invalid time value for '%s': %w", paramName, err)
+	}
+	return result, nil
 }
 
 func parseTime(s string) (time.Time, error) {

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -14,16 +14,12 @@ import (
 func Query(queryEngine *promql.Engine, queryable *query.Queryable) http.Handler {
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ts time.Time
-		if t := r.FormValue("time"); t != "" {
-			var err error
-			ts, err = parseTime(t)
-			if err != nil {
-				log.Error("msg", "Query error", "err", err.Error())
-				respondError(w, http.StatusBadRequest, err, "bad_data")
-				return
-			}
-		} else {
-			ts = time.Now()
+		var err error
+		ts, err = parseTimeParam(r, "time", time.Now())
+		if err != nil {
+			log.Error("msg", "Query error", "err", err.Error())
+			respondError(w, http.StatusBadRequest, err, "bad_data")
+			return
 		}
 
 		ctx := r.Context()

--- a/pkg/api/series.go
+++ b/pkg/api/series.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
+	"strings"
+
 	"github.com/NYTimes/gziphandler"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -11,8 +14,6 @@ import (
 	"github.com/timescale/timescale-prometheus/pkg/log"
 	"github.com/timescale/timescale-prometheus/pkg/promql"
 	"github.com/timescale/timescale-prometheus/pkg/query"
-	"net/http"
-	"strings"
 )
 
 func Series(queryable *query.Queryable) http.Handler {
@@ -27,13 +28,13 @@ func Series(queryable *query.Queryable) http.Handler {
 			return
 		}
 
-		start, err := parseTime(r.FormValue("start"))
+		start, err := parseTimeParam(r, "start", minTime)
 		if err != nil {
 			log.Info("msg", "Query bad request:"+err.Error())
 			respondError(w, http.StatusBadRequest, err, "bad_data")
 			return
 		}
-		end, err := parseTime(r.FormValue("end"))
+		end, err := parseTimeParam(r, "end", maxTime)
 		if err != nil {
 			log.Info("msg", "Query bad request:"+err.Error())
 			respondError(w, http.StatusBadRequest, err, "bad_data")


### PR DESCRIPTION
When start/end timestamp values are not sent to a query, Prometheus sets them
min/max timestamp values. These values are outside of Prometheus date/time
ranges and cause errors when used in SQL queries. This fix limits those values
to year 1970 for min and year 3000 for max.

Closes #125 