### PR TITLE
Update tests to detect labels issue

### DIFF
--- a/pkg/pgmodel/end_to_end_tests/query_integration_test.go
+++ b/pkg/pgmodel/end_to_end_tests/query_integration_test.go
@@ -1131,6 +1131,7 @@ func generateLargeTimeseries() []prompb.TimeSeries {
 	metrics := []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{
+				{Name: "aaa", Value: "000"},
 				{Name: MetricNameLabelName, Value: "metric_1"},
 				{Name: "foo", Value: "bar"},
 				{Name: "instance", Value: "1"},
@@ -1214,7 +1215,7 @@ func TestPushdown(t *testing.T) {
 			res: promql.Result{
 				Value: promql.Matrix{promql.Series{
 					Points: []promql.Point{{V: 20, T: startTime + 300000}, {V: 20, T: startTime + 330000}},
-					Metric: labels.FromStrings("foo", "bar", "instance", "1")},
+					Metric: labels.FromStrings("foo", "bar", "instance", "1", "aaa", "000")},
 				},
 			},
 		},
@@ -1225,7 +1226,7 @@ func TestPushdown(t *testing.T) {
 			res: promql.Result{
 				Value: promql.Vector{promql.Sample{
 					Point:  promql.Point{V: 20, T: startTime + 300*1000},
-					Metric: labels.FromStrings("foo", "bar", "instance", "1")},
+					Metric: labels.FromStrings("foo", "bar", "instance", "1", "aaa", "000")},
 				},
 			},
 		},


### PR DESCRIPTION
Our labels were too well behaved; the order in which we queried them
was always the order they were stored. This adds another label to
ensure that there's some noise in how we query.