### PR TITLE
Fix connection leaks

### DIFF
--- a/pkg/pgmodel/sql_test.go
+++ b/pkg/pgmodel/sql_test.go
@@ -813,6 +813,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 					{Type: prompb.LabelMatcher_NEQ, Name: "foo", Value: "bar"},
 				},
 			},
+			result: []*prompb.TimeSeries{},
 			sqlQueries: []sqlQuery{
 				{
 					sql: "SELECT m.metric_name, array_agg(s.id)\n\t" +
@@ -1055,6 +1056,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 					err:     error(nil),
 				},
 				{
+					sql:     "SELECT table_name FROM _prom_catalog.get_metric_table_name_if_exists($1)",
+					args:    []interface{}{"bar"},
+					results: rowResults{{"bar"}},
+					err:     error(nil),
+				},
+				{
 					sql: "SELECT s.labels, array_agg(m.time ORDER BY time), array_agg(m.value ORDER BY time)\n\t" +
 						"FROM \"prom_data\".\"foo\" m\n\t" +
 						"INNER JOIN \"prom_data_series\".\"foo\" s\n\t" +
@@ -1065,12 +1072,6 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"GROUP BY s.id",
 					args:    []interface{}(nil),
 					results: rowResults{{[]int64{3}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
-					err:     error(nil),
-				},
-				{
-					sql:     "SELECT table_name FROM _prom_catalog.get_metric_table_name_if_exists($1)",
-					args:    []interface{}{"bar"},
-					results: rowResults{{"bar"}},
 					err:     error(nil),
 				},
 				{
@@ -1140,6 +1141,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 					err:     error(nil),
 				},
 				{
+					sql:     "SELECT table_name FROM _prom_catalog.get_metric_table_name_if_exists($1)",
+					args:    []interface{}{"bar"},
+					results: rowResults{{"bar"}},
+					err:     error(nil),
+				},
+				{
 					sql: "SELECT s.labels, array_agg(m.time ORDER BY time), array_agg(m.value ORDER BY time)\n\t" +
 						"FROM \"prom_data\".\"foo\" m\n\t" +
 						"INNER JOIN \"prom_data_series\".\"foo\" s\n\t" +
@@ -1150,12 +1157,6 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"GROUP BY s.id",
 					args:    []interface{}(nil),
 					results: rowResults{{[]int64{5}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
-					err:     error(nil),
-				},
-				{
-					sql:     "SELECT table_name FROM _prom_catalog.get_metric_table_name_if_exists($1)",
-					args:    []interface{}{"bar"},
-					results: rowResults{{"bar"}},
 					err:     error(nil),
 				},
 				{
@@ -1398,7 +1399,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(result, c.result) {
-				t.Errorf("unexpected result:\ngot\n%v\nwanted\n%v", result, c.result)
+				t.Errorf("unexpected result:\ngot\n%#v\nwanted\n%+v", result, c.result)
 			}
 		})
 	}

--- a/pkg/pgmodel/sql_utils.go
+++ b/pkg/pgmodel/sql_utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
@@ -185,4 +186,15 @@ func getMetricTableName(conn pgxConn, metric string) (string, bool, error) {
 	}
 
 	return tableName, possiblyNew, nil
+}
+
+func timestamptzToMs(t pgtype.Timestamptz) int64 {
+	switch t.InfinityModifier {
+	case pgtype.NegativeInfinity:
+		return math.MinInt64
+	case pgtype.Infinity:
+		return math.MaxInt64
+	default:
+		return t.Time.UnixNano() / 1e6
+	}
 }


### PR DESCRIPTION
Keeping around a `pgx.Rows` is dangerous, as doing so keeps a lock on the underlying connection. This means that the connecter can self-starve if it gets partway through a Rows and decides it needs to fetch more data from the database. To fix this, this commit materializes all `pgx.Rows` into a `[]timescaleRow` as soon as possible.

(Further, It looks like there's no guarantee that a `SeriesSet` will be read until the end anyway)

This commit also refactors the `TestPGXQuerierQuery` test, as updating the old version to the new code was too onerous, and batches multi-metrics queries together, as I was rewriting that code anyway. It seems to give a nice performance increase.