### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have any questions, please join the #prometheus channel on
 [TimescaleDB Slack](https://slack.timescale.com/), or the
 [Timescale-Prometheus Users Google Group](https://groups.google.com/forum/#!forum/timescale-prometheus-users).
 
-### About TimescaleDB
+## 🐯 About TimescaleDB
 
 **[TimescaleDB](https://github.com/timescale/timescaledb)** is a
 **distributed time-series database built on PostgreSQL** that scales to
@@ -43,171 +43,89 @@ with 4,000+ members). Users include Comcast, Fujitsu,
 Schneider Electric, Siemens, Walmart, Warner Music, and thousands of
 others.
 
-TimescaleDB is already the main metrics database behind one of the
-largest monitoring providers in the world, and is the preferred
-time-series database backend natively supported by Zabbix. It is
-natively supported by Grafana via the PostgreSQL/TimescaleDB datasource.
+Developers and organizations around the world trust TimescaleDB with their
+time-series data. AppDynamics (now part of Cisco Systems and one of the
+largest application performance monitoring providers) relies on TimescaleDB
+as its main metrics database. TimescaleDB is also the preferred (recommended)
+backend datasource for Zabbix users and is natively supported in Grafana.
 
-## Getting started with Helm (recommended)
+## 🔧 Choose your own (installation) adventure
 
-The quickest way to get started is by using
-[The Observability Stack for Kubernetes (tobs)](https://github.com/timescale/tobs),
-which provides a helm chart and CLI tool for installing an end-to-end
-observability stack.
+We have four main ways to set up Timescale-Prometheus:
 
-The following command will install Prometheus, TimescaleDB,
-Timescale-Prometheus Connector, and Grafana
-into your Kubernetes cluster:
-```
-helm repo add timescale https://charts.timescale.com/
-helm repo update
-helm install --devel <release_name> timescale/tobs
-```
+#### tobs (recommended for Kubernetes environments)
 
-## Quick tips
+[The Observability Suite for Kubernetes][tobs] is a
+CLI tool and Helm chart that makes installing a full observability suite into your
+Kubernetes cluster really easy. Tobs includes Prometheus, TimescaleDB,
+Timescale-Prometheus Connector, and Grafana.
 
-### Configuring Data Retention
+To get started, run the following in your terminal, then follow the on-screen instructions.
 
-By default, data is stored for 90 days and then deleted.
-This default can be changed in SQL by using the SQL function
-`set_default_retention_period(new interval)`.  For example,
-```
-SELECT set_default_retention_period(180 * INTERVAL '1 day')
+```bash
+curl --proto '=https' --tlsv1.2 -sSLf  https://tsdb.co/install-tobs-sh |sh
 ```
 
-You can also override this default on a per-metric basis using
-the SQL function `set_metric_retention_period(metric_name, interval)`
-and undo this override with `reset_metric_retention_period(metric_name)`.
+Or visit the [tobs GitHub repo][tobs] for more information and instructions
+on advanced configuration.
 
-Note: The default applies to all metrics that do not have override,
-no matter whether they were created before or after the call to
-`set_default_retention_period`.
+#### 🐳 Docker
 
-### Working with SQL data
+We provide [docker images](/releases) with every release.
+
+Instructions on how to use our docker images are available [here](docs/docker.md).
+
+#### 🔟 Binaries
+
+We have [pre-packaged binaries](/releases) available for MacOS and Linux on both the x86_64 and i386 architectures.
+Instructions on how to use our prepackaged binaries are available [here](docs/binary.md).
+
+You can also [build binaries from source](docs/binary.md#building-from-source).
+
+#### ⎈ Helm (sub)chart for Timescale-Prometheus Connector only
+
+A Helm chart for only the Timescale-Prometheus Connector is available in
+the [helm-chart directory](helm-chart/README.md) of this repository.
+
+This is used as a Helm dependency from the `tobs`
+[Helm chart](https://github.com/timescale/tobs/tree/master/chart) and can be used as a dependency in your own custom Helm chart as well.
+
+## 🔍 Analyzing the data using SQL
 
 We describe how to use our pre-defined views and functions to work with the prometheus data in [the SQL schema doc](docs/sql_schema.md).
 
 A Reference for our SQL API is [available here](docs/sql_api.md).
 
-### Prometheus HTTP API
+## 💡 Quick tips
 
-The Timescale-Prometheus Connector can be used directly as a Prometheus Data Source in Grafana, or other software.
+### Configuring Data Retention
 
-It implements some endpoints of the currently stable (V1)
-[Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api).
-The API is accessible at `http://timescale_prometheus_connector:9201/api/v1` and can be used to execute instant or range
-PromQL queries against the data in TimescaleDB, as well as retrieve the metadata for series, label names and label
-values.
+By default, data is stored for 90 days and then deleted. This
+default can be changed globally or overridden for individual
+metrics.
+
+If using tobs, these settings can be changed using the
+`tobs metrics retention` command (use
+`tobs metrics retention -h` to see all options).
+
+These setting can also be changed using the appropriate
+[SQL commands](docs/sql_schema.md#data-retention).
+
+### 🌐 Prometheus HTTP API
+
+The Timescale-Prometheus Connector can be used directly as a Prometheus Data
+Source in Grafana, or other software.
+
+The connector implements some endpoints of the currently stable (V1) [Prometheus HTTP
+API](https://prometheus.io/docs/prometheus/latest/querying/api). The API is
+accessible at `http://<timescale_prometheus_connector_address>:9201/api/v1` and can be
+used to execute instant or range PromQL queries against the data in
+TimescaleDB, as well as retrieve the metadata for series, label names and
+label values.
 
 A Reference for the implemented endpoints of the Prometheus HTTP API is [available here](docs/prometheus_api.md)
 
-## Advanced
-
-### Configuring the Helm Chart
-
-To get a fully-documented configuration file for
-`tobs`, please run:
-
-```
-helm show values timescale/tobs > my_values.yml
-```
-
-You can then edit `my_values.yml` and deploy the release with the
-following command:
-
-```
-helm upgrade --install <release_name> --values my_values.yml timescale/tobs
-```
-
-By default, the `tobs` Helm chart sets up a
-single-instance of TimescaleDB; if you are
-interested in a replicated setup for high-availabilty with automated
-backups, please see
-[this github repo](https://github.com/timescale/timescaledb-kubernetes/tree/master/charts/timescaledb-single) for additional instructions.
-
-### Helm (sub)chart for Timescale-Prometheus Connector only
-
-A Helm chart for only the Timescale-Prometheus Connector is available in
-the [helm-chart directory](helm-chart/README.md) of this repository.
-
-This is used as a dependency from the `tobs` Helm
-chart and can be used as a dependency in your own custom Helm chart.
-
-## Non-Helm deployment
-
-### Non-Helm installation methods
-
-Any non-helm installations also need to make sure the `drop_chunks`
-procedure on a regular
-basis (e.g. via CRON). We recommend executing it every 30 minutes.
-This is necessary to execute data retention policies according to the
-configured policy. This is set up automatically in helm.
-
-We also recommend running this with a Timescaledb installation that
-includes the `timescale_prometheus_extra`
-Postgres extension. While this isn't a requirement, it does optimize
-certain queries. A docker image of Timescaledb with the extension is
-available at on Docker Hub at
-[`timescaledev/timescale_prometheus_extra:latest-pg12`](https://hub.docker.com/r/timescaledev/timescale_prometheus_extra).
-Instructions on how to compile and install the extension are in the
-extensions [README](extension/Readme.md).
-Please note that the extension requires Postgres version 12 of newer.
-
-#### Binaries
-
-You can download pre-built binaries for the Timescale-Prometheus
-Connector [on our release page](https://github.com/timescale/timescale-prometheus/releases).
-
-#### Docker
-
-A docker image for the Timescale-Prometheus Connector is available
-on Docker Hub at [timescale/timescale-prometheus](https://hub.docker.com/r/timescale/timescale-prometheus/).
-
-A docker image of timescaledb with the `timescale_prometheus_extra`
-extension is available at on Docker Hub at
-[`timescaledev/timescale_prometheus_extra:latest-pg12`](https://hub.docker.com/r/timescaledev/timescale_prometheus_extra).
-
-#### Building from source
-
-Before building, make sure the following prerequisites are installed:
-
-* [Go](https://golang.org/dl/)
-
-The Timescale-Prometheus Connector is a Go project managed by go
-modules. You can download it in
-any directory and on the first build it will download it's required
-dependencies.
-
-```bash
-# Fetch the source code of Timescale-Prometheus in any directory
-$ git clone git@github.com:timescale/timescale-prometheus.git
-$ cd ./timescale-prometheus
-
-# Install the Timescale-Prometheus Connector binary (will automatically detect and download)
-# dependencies.
-$ cd cmd/timescale-prometheus
-$ go install
-
-# Building without installing will also fetch the required dependencies
-$ go build ./...
-```
-
-You can build the Docker container using the [Dockerfile](Dockerfile).
-
-### Non-Helm Configuration
-
-#### Configuring Prometheus to use this remote storage connector
-
-You must tell prometheus to use this remote storage connector by adding
-the following lines to `prometheus.yml`:
-```
-remote_write:
-  - url: "http://<connector-address>:9201/write"
-remote_read:
-  - url: "http://<connector-address>:9201/read"
-```
-
-#### Configuring Prometheus to filter which metrics are sent (optional)
+### Configuring Prometheus to filter which metrics are sent (optional)
 
 You can limit the metrics being sent to the adapter (and thus being
 stored in your long-term storage) by setting up `write_relabel_configs`
@@ -232,14 +150,7 @@ Additional information about setting up relabel configs, the
 `source_labels` field, and the possible actions can be found in the
 [Prometheus Docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
 
-#### Configuring the Timescale-Prometheus Connector Binary
-
-The Timescale-Prometheus Connector Binary is configured either through
-CLI flags or environment variables. The list of all available flags is
-displayed on the help `timescale-prometheus -h` command. All
-environment variables are prefixed with `TS_PROM`.
-
-## Contributing
+## ✏️ Contributing
 
 We welcome contributions to the Timescale-Prometheus Connector, which is
 licensed and released under the open-source Apache License, Version 2.
@@ -250,3 +161,4 @@ Agreement](https://cla-assistant.io/timescale/timescale-prometheus)
 (CLA) if you're a new contributor.
 
 [design-doc]: https://tsdb.co/prom-design-doc
+[tobs]: https://github.com/timescale/tobs

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -1,0 +1,63 @@
+# 🔟 Binaries
+
+## 🔧 Installing pre-built binaries
+
+You can download pre-built binaries for the Timescale-Prometheus
+Connector [on our release page](/releases).
+
+We recommend installing the [timescale_prometheus_extra](/extension)
+PostgreSQL extension into the TimescaleDB database you are connecting to.
+Instructions on how to compile and install the extension are in the
+extensions [README](/extension/Readme.md). While this isn't a requirement, it
+does optimize certain queries.
+Please note that the extension requires Postgres version 12 of newer.
+
+## 🕞 Setting up cron jobs
+
+Binary installations also need to make sure the `execute_maintenance()`
+procedure on a regular basis (e.g. via cron). We recommend executing it every
+30 minutes. This is necessary to execute maintenance tasks such as enforcing
+data retention policies according to the configured policy.
+
+## 🔥 Configuring Prometheus to use this remote storage connector
+
+You must tell prometheus to use this remote storage connector by adding
+the following lines to `prometheus.yml`:
+```
+remote_write:
+  - url: "http://<connector-address>:9201/write"
+remote_read:
+  - url: "http://<connector-address>:9201/read"
+```
+
+## ⚙️ Configuration
+
+The Timescale-Prometheus Connector binary is configured either through
+CLI flags or environment variables. The list of all available flags is
+displayed on the help `timescale-prometheus -h` command. All
+environment variables are prefixed with `TS_PROM`.
+
+## 🛠 Building from source
+
+Before building, make sure the following prerequisites are installed:
+
+* [Go](https://golang.org/dl/)
+
+The Timescale-Prometheus Connector is a Go project managed by go
+modules. You can download it in
+any directory and on the first build it will download it's required
+dependencies.
+
+```bash
+# Fetch the source code of Timescale-Prometheus in any directory
+$ git clone git@github.com:timescale/timescale-prometheus.git
+$ cd ./timescale-prometheus
+
+# Install the Timescale-Prometheus Connector binary (will automatically detect and download)
+# dependencies.
+$ cd cmd/timescale-prometheus
+$ go install
+
+# Building without installing will also fetch the required dependencies
+$ go build ./...
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,39 @@
+# 🐳 Docker
+
+## 🔧 Running Docker
+
+A docker image for the Timescale-Prometheus Connector is available
+on Docker Hub at [timescale/timescale-prometheus](https://hub.docker.com/r/timescale/timescale-prometheus/).
+
+A docker image of TimescaleDB with the `timescale_prometheus_extra`
+extension is available at on Docker Hub at
+[`timescaledev/timescale_prometheus_extra:latest-pg12`](https://hub.docker.com/r/timescaledev/timescale_prometheus_extra).
+
+## 🕞 Setting up cron jobs
+
+Docker installations also need to make sure the `execute_maintenance()`
+procedure on a regular basis (e.g. via cron). We recommend executing it every
+30 minutes. This is necessary to execute maintenance tasks such as enforcing
+data retention policies according to the configured policy.
+
+## 🔥 Configuring Prometheus to use this remote storage connector
+
+You must tell prometheus to use this remote storage connector by adding
+the following lines to `prometheus.yml`:
+```
+remote_write:
+  - url: "http://<connector-address>:9201/write"
+remote_read:
+  - url: "http://<connector-address>:9201/read"
+```
+
+## ⚙️ Configuration
+
+The docker image is configured either through CLI flags or environment variables.
+The list of all available flags is displayed when run with the `-h` flag
+(e.g. `docker run timescale/timescale-prometheus -h`). All
+environment variables are prefixed with `TS_PROM`.
+
+## 🛠 Building from source
+
+You can build the Docker container using the [Dockerfile](/Dockerfile)

--- a/docs/sql_schema.md
+++ b/docs/sql_schema.md
@@ -241,4 +241,20 @@ Therefore you need to provide the entire json object if using the
 function above. For partial matches see the Containment
 section above.
 
+## Data retention
+
+This default data retention period can be changed by using the SQL function
+`set_default_retention_period(new interval)`.  For example,
+```
+SELECT set_default_retention_period(180 * INTERVAL '1 day')
+```
+
+You can also override this default on a per-metric basis using
+the SQL function `set_metric_retention_period(metric_name, interval)`
+and undo this override with `reset_metric_retention_period(metric_name)`.
+
+Note: The default applies to all metrics that do not have override,
+no matter whether they were created before or after the call to
+`set_default_retention_period`.
+
 [design-doc]: https://tsdb.co/prom-design-doc


### PR DESCRIPTION
The goal of this commit is to streamline our documentation.
Namely we wanted to:

- Make instructions for various installation methods more streamlined.
  We now show all installation methods in one place in the README
  with links to more detailed instructions.
- Docker and Binary instructions become more complete and self-contained
  at the cost of some duplication.
- Make the main README shorter and more to-the-point
- Make the links to the SQL stuff more prominent and easy to find.
  Some of this is done but more can be done later.