### PR TITLE
Add ssl mode config option

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -70,6 +70,7 @@ helm install --name my-release -f myvalues.yaml .
 | `connection.host.nameTemplate`    | The template for generating the hostname of the db | `{{ .Release.Name }}.{{ .Release.Namespace}}.svc.cluster.local` |
 | `connection.port`                 | Port the db listens to                      | `5432`                             |
 | `connection.dbName`               | Database name in TimescaleDB to connect to  | `timescale`                        |
+| `connection.sslMode`              | SSL mode for connection                     | `require`                          |
 | `service.port`                    | Port the connector pods will accept connections on | `9201`                      |
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -46,7 +46,7 @@ spec:
             - name: TS_PROM_DB_NAME
               value: {{ .Values.connection.dbName }}
             - name: TS_PROM_DB_SSL_MODE
-              value: require
+              value: {{ .Values.connection.sslMode }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -21,6 +21,7 @@ connection:
     #   nameTemplate: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
     nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
   port: 5432
+  sslMode: require
   # database name in which to store the metrics
   # must be created before start
   dbName: timescale


### PR DESCRIPTION
Based on #224 I think timescale-prometheus now respects `TS_PROM_DB_SSL_MODE`? (And the config option was already in the helm chart.) I haven't looked too deeply honestly, so it might not even be configurable yet. 