### PR TITLE
Update lock handling for migrate

### DIFF
--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -1,0 +1,36 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/runner"
+	"github.com/timescale/timescale-prometheus/pkg/version"
+)
+
+func main() {
+	logLevel := flag.String("log-level", "debug", "The log level to use [ \"error\", \"warn\", \"info\", \"debug\" ].")
+	cfg := &runner.Config{}
+	cfg, err := runner.ParseFlags(cfg)
+	if err != nil {
+		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
+		fmt.Println("Fatal error: cannot parse flags ", err)
+		os.Exit(1)
+	}
+	err = log.Init(*logLevel)
+	if err != nil {
+		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
+		fmt.Println("Fatal error: cannot start logger", err)
+		os.Exit(1)
+	}
+	err = runner.Run(cfg)
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -21,13 +21,13 @@ import (
 
 // Config for the database
 type Config struct {
-	host                    string
-	port                    int
-	user                    string
-	password                string
-	database                string
-	sslMode                 string
-	dbConnectRetries        int
+	Host                    string
+	Port                    int
+	User                    string
+	Password                string
+	Database                string
+	SslMode                 string
+	DbConnectRetries        int
 	AsyncAcks               bool
 	ReportInterval          int
 	LabelsCacheSize         uint64
@@ -39,13 +39,13 @@ type Config struct {
 
 // ParseFlags parses the configuration flags specific to PostgreSQL and TimescaleDB
 func ParseFlags(cfg *Config) *Config {
-	flag.StringVar(&cfg.host, "db-host", "localhost", "The TimescaleDB host")
-	flag.IntVar(&cfg.port, "db-port", 5432, "The TimescaleDB port")
-	flag.StringVar(&cfg.user, "db-user", "postgres", "The TimescaleDB user")
-	flag.StringVar(&cfg.password, "db-password", "", "The TimescaleDB password")
-	flag.StringVar(&cfg.database, "db-name", "timescale", "The TimescaleDB database")
-	flag.StringVar(&cfg.sslMode, "db-ssl-mode", "require", "The TimescaleDB connection ssl mode")
-	flag.IntVar(&cfg.dbConnectRetries, "db-connect-retries", 0, "How many times to retry connecting to the database")
+	flag.StringVar(&cfg.Host, "db-host", "localhost", "The TimescaleDB host")
+	flag.IntVar(&cfg.Port, "db-port", 5432, "The TimescaleDB port")
+	flag.StringVar(&cfg.User, "db-user", "postgres", "The TimescaleDB user")
+	flag.StringVar(&cfg.Password, "db-password", "", "The TimescaleDB password")
+	flag.StringVar(&cfg.Database, "db-name", "timescale", "The TimescaleDB database")
+	flag.StringVar(&cfg.SslMode, "db-ssl-mode", "require", "The TimescaleDB connection ssl mode")
+	flag.IntVar(&cfg.DbConnectRetries, "db-connect-retries", 0, "How many times to retry connecting to the database")
 	flag.BoolVar(&cfg.AsyncAcks, "async-acks", false, "Ack before data is written to DB")
 	flag.IntVar(&cfg.ReportInterval, "tput-report", 0, "interval in seconds at which throughput should be reported")
 	flag.Uint64Var(&cfg.LabelsCacheSize, "labels-cache-size", 10000, "maximum number of labels to cache")
@@ -133,7 +133,7 @@ func NewClientWithPool(cfg *Config, numCopiers int, pool *pgxpool.Pool) (*Client
 // GetConnectionStr returns a Postgres connection string
 func (cfg *Config) GetConnectionStr() string {
 	return fmt.Sprintf("host=%v port=%v user=%v dbname=%v password='%v' sslmode=%v connect_timeout=10",
-		cfg.host, cfg.port, cfg.user, cfg.database, cfg.password, cfg.sslMode)
+		cfg.Host, cfg.Port, cfg.User, cfg.Database, cfg.Password, cfg.SslMode)
 }
 
 func (cfg *Config) GetNumConnections() (min int, max int, numCopiers int, err error) {

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -192,7 +192,9 @@ func (cfg *Config) GetNumConnections() (min int, max int, numCopiers int, err er
 
 // Close closes the client and performs cleanup
 func (c *Client) Close() {
+	log.Info("Shutting down Client")
 	c.ingestor.Close()
+	c.Connection.Close()
 }
 
 // Ingest writes the timeseries object into the DB

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -102,7 +102,7 @@ func Run(cfg *Config) error {
 
 	promMetrics := api.InitMetrics()
 
-	client, err := createClient(cfg, promMetrics)
+	client, err := CreateClient(cfg, promMetrics)
 	if err != nil {
 		log.Error("msg", "aborting startup due to error", "err", util.MaskPassword(err.Error()))
 		return startupError
@@ -138,7 +138,7 @@ func Run(cfg *Config) error {
 	return nil
 }
 
-func createClient(cfg *Config, promMetrics *api.Metrics) (*pgclient.Client, error) {
+func CreateClient(cfg *Config, promMetrics *api.Metrics) (*pgclient.Client, error) {
 	var schemaVersionLease *util.PgAdvisoryLock
 	if cfg.UseVersionLease {
 		// migration lock logic

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,7 +1,7 @@
 // This file and its contents are licensed under the Apache License 2.0.
 // Please see the included NOTICE for copyright information and
 // LICENSE for a copy of the license.
-package main
+package runner
 
 // Based on the Prometheus remote storage example:
 // documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net/http"
 	pprof "net/http/pprof"
-	"os"
 	"regexp"
 	"strings"
 	"sync/atomic"
@@ -31,11 +30,10 @@ import (
 	"github.com/timescale/timescale-prometheus/pkg/version"
 )
 
-type config struct {
+type Config struct {
 	listenAddr        string
 	telemetryPath     string
 	pgmodelCfg        pgclient.Config
-	logLevel          string
 	haGroupLockID     int64
 	restElection      bool
 	prometheusTimeout time.Duration
@@ -55,21 +53,10 @@ var (
 	elector            *util.Elector
 	appVersion         = pgmodel.VersionInfo{Version: version.Version, CommitHash: version.CommitHash}
 	migrationLockError = fmt.Errorf("Could not acquire migration lock. Ensure there are no other connectors running and try again.")
+	startupError       = fmt.Errorf("startup error")
 )
 
-func main() {
-	cfg, err := parseFlags()
-	if err != nil {
-		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
-		fmt.Println("Fatal error: cannot parse flags ", err)
-		os.Exit(1)
-	}
-	err = log.Init(cfg.logLevel)
-	if err != nil {
-		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
-		fmt.Println("Fatal error: cannot start logger", err)
-		os.Exit(1)
-	}
+func Run(cfg *Config) error {
 	log.Info("msg", "Version:"+version.Version+"; Commit Hash: "+version.CommitHash)
 	log.Info("config", util.MaskPassword(fmt.Sprintf("%+v", cfg)))
 
@@ -78,11 +65,11 @@ func main() {
 	client, err := createClient(cfg, promMetrics)
 	if err != nil {
 		log.Error("msg", "aborting startup due to error", "err", util.MaskPassword(err.Error()))
-		os.Exit(1)
+		return startupError
 	}
 
 	if client == nil {
-		os.Exit(0)
+		return nil
 	}
 
 	defer client.Close()
@@ -105,14 +92,13 @@ func main() {
 
 	if err != nil {
 		log.Error("msg", "Listen failure", "err", err)
-		os.Exit(1)
+		return startupError
 	}
+
+	return nil
 }
 
-func parseFlags() (*config, error) {
-
-	cfg := &config{}
-
+func ParseFlags(cfg *Config) (*Config, error) {
 	pgclient.ParseFlags(&cfg.pgmodelCfg)
 
 	flag.StringVar(&cfg.listenAddr, "web-listen-address", ":9201", "Address to listen on for web endpoints.")
@@ -121,7 +107,6 @@ func parseFlags() (*config, error) {
 	var corsOriginFlag string
 	var migrateOption string
 	flag.StringVar(&corsOriginFlag, "web-cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
-	flag.StringVar(&cfg.logLevel, "log-level", "debug", "The log level to use [ \"error\", \"warn\", \"info\", \"debug\" ].")
 	flag.Int64Var(&cfg.haGroupLockID, "leader-election-pg-advisory-lock-id", 0, "Unique advisory lock id per adapter high-availability group. Set it if you want to use leader election implementation based on PostgreSQL advisory lock.")
 	flag.DurationVar(&cfg.prometheusTimeout, "leader-election-pg-advisory-lock-prometheus-timeout", -1, "Adapter will resign if there are no requests from Prometheus within a given timeout (0 means no timeout). "+
 		"Note: make sure that only one Prometheus instance talks to the adapter. Timeout value should be co-related with Prometheus scrape interval but add enough `slack` to prevent random flips.")
@@ -153,7 +138,7 @@ func parseFlags() (*config, error) {
 	return cfg, nil
 }
 
-func createClient(cfg *config, promMetrics *api.Metrics) (*pgclient.Client, error) {
+func createClient(cfg *Config, promMetrics *api.Metrics) (*pgclient.Client, error) {
 	var schemaVersionLease *util.PgAdvisoryLock
 	if cfg.useVersionLease {
 		// migration lock logic
@@ -163,10 +148,11 @@ func createClient(cfg *config, promMetrics *api.Metrics) (*pgclient.Client, erro
 		// lock on schemaLockId, and we attempt to grab an exclusive lock on it
 		// before running migrate. This implies that migration must be run when no
 		// other connector is running.
-		schemaVersionLease, err := util.NewPgAdvisoryLock(schemaLockId, cfg.pgmodelCfg.GetConnectionStr())
+		var err error
+		schemaVersionLease, err = util.NewPgAdvisoryLock(schemaLockId, cfg.pgmodelCfg.GetConnectionStr())
 		if err != nil {
 			log.Error("msg", "error creating schema version lease", "err", err)
-			os.Exit(1)
+			return nil, startupError
 		}
 		// after the client has started it's in charge of maintaining the leases
 		defer schemaVersionLease.Close()
@@ -201,6 +187,8 @@ func createClient(cfg *config, promMetrics *api.Metrics) (*pgclient.Client, erro
 		if !locked {
 			return nil, fmt.Errorf("could not acquire schema version lease. is a migration in progress?")
 		}
+	} else {
+		log.Warn("msg", "skipping schema version lease")
 	}
 
 	// Check the database is on the correct version.
@@ -247,7 +235,7 @@ func createClient(cfg *config, promMetrics *api.Metrics) (*pgclient.Client, erro
 	return client, nil
 }
 
-func initElector(cfg *config, metrics *api.Metrics) (*util.Elector, error) {
+func initElector(cfg *Config, metrics *api.Metrics) (*util.Elector, error) {
 	if cfg.restElection && cfg.haGroupLockID != 0 {
 		return nil, fmt.Errorf("Use either REST or PgAdvisoryLock for the leader election")
 	}
@@ -279,7 +267,7 @@ func initElector(cfg *config, metrics *api.Metrics) (*util.Elector, error) {
 	return &scheduledElector.Elector, nil
 }
 
-func migrate(cfg *pgclient.Config, appVersion pgmodel.VersionInfo, leaseLock util.AdvisoryLock) error {
+func migrate(cfg *pgclient.Config, appVersion pgmodel.VersionInfo, leaseLock *util.PgAdvisoryLock) error {
 	// At startup migrators attempt to grab the schema-version lock. If this
 	// fails that means some other connector is running. All is not lost: some
 	// other connector may have migrated the DB to the correct version. We warn,
@@ -300,6 +288,8 @@ func migrate(cfg *pgclient.Config, appVersion pgmodel.VersionInfo, leaseLock uti
 				log.Error("msg", "error while releasing migration lock", "err", err)
 			}
 		}()
+	} else {
+		log.Warn("msg", "skipping migration lock")
 	}
 
 	db, err := pgxpool.Connect(context.Background(), cfg.GetConnectionStr())

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -35,38 +35,38 @@ func TestInitElector(t *testing.T) {
 		{
 			name: "Cannot create REST election with a group lock ID",
 			cfg: &Config{
-				haGroupLockID: 1,
-				restElection:  true,
+				HaGroupLockID: 1,
+				RestElection:  true,
 			},
 			shouldError: true,
 		},
 		{
 			name: "Create REST elector",
 			cfg: &Config{
-				haGroupLockID: 0,
-				restElection:  true,
+				HaGroupLockID: 0,
+				RestElection:  true,
 			},
 			electionType: reflect.TypeOf(&util.RestElection{}),
 		},
 		{
 			name: "Cannot create scheduled elector, no group lock ID and not rest election",
 			cfg: &Config{
-				haGroupLockID: 0,
+				HaGroupLockID: 0,
 			},
 		},
 		{
 			name: "Prometheus timeout not set for PG advisory lock",
 			cfg: &Config{
-				haGroupLockID:     1,
-				prometheusTimeout: -1,
+				HaGroupLockID:     1,
+				PrometheusTimeout: -1,
 			},
 			shouldError: true,
 		},
 		{
 			name: "Can't get advisory lock, couldn't connect to DB",
 			cfg: &Config{
-				haGroupLockID:     1,
-				prometheusTimeout: 0,
+				HaGroupLockID:     1,
+				PrometheusTimeout: 0,
 			},
 			shouldError: true,
 		},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"flag"
@@ -28,13 +28,13 @@ func TestInitElector(t *testing.T) {
 	// TODO: refactor the function to be fully testable without using a DB.
 	testCases := []struct {
 		name         string
-		cfg          *config
+		cfg          *Config
 		shouldError  bool
 		electionType reflect.Type
 	}{
 		{
 			name: "Cannot create REST election with a group lock ID",
-			cfg: &config{
+			cfg: &Config{
 				haGroupLockID: 1,
 				restElection:  true,
 			},
@@ -42,7 +42,7 @@ func TestInitElector(t *testing.T) {
 		},
 		{
 			name: "Create REST elector",
-			cfg: &config{
+			cfg: &Config{
 				haGroupLockID: 0,
 				restElection:  true,
 			},
@@ -50,13 +50,13 @@ func TestInitElector(t *testing.T) {
 		},
 		{
 			name: "Cannot create scheduled elector, no group lock ID and not rest election",
-			cfg: &config{
+			cfg: &Config{
 				haGroupLockID: 0,
 			},
 		},
 		{
 			name: "Prometheus timeout not set for PG advisory lock",
-			cfg: &config{
+			cfg: &Config{
 				haGroupLockID:     1,
 				prometheusTimeout: -1,
 			},
@@ -64,7 +64,7 @@ func TestInitElector(t *testing.T) {
 		},
 		{
 			name: "Can't get advisory lock, couldn't connect to DB",
-			cfg: &config{
+			cfg: &Config{
 				haGroupLockID:     1,
 				prometheusTimeout: 0,
 			},

--- a/pkg/util/election_test.go
+++ b/pkg/util/election_test.go
@@ -91,7 +91,7 @@ func TestRESTApi(t *testing.T) {
 
 func TestPgAdvisoryLock(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock, err := NewPgAdvisoryLock(1, connectURL)
+		lock, err := NewPgLeaderLock(1, connectURL)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -100,7 +100,7 @@ func TestPgAdvisoryLock(t *testing.T) {
 			t.Error("Couldn't obtain the lock")
 		}
 
-		newLock, err := NewPgAdvisoryLock(1, connectURL)
+		newLock, err := NewPgLeaderLock(1, connectURL)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func TestPgAdvisoryLock(t *testing.T) {
 
 func TestElector(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock1, err := NewPgAdvisoryLock(2, connectURL)
+		lock1, err := NewPgLeaderLock(2, connectURL)
 		if err != nil {
 			t.Error(err)
 		}
@@ -141,7 +141,7 @@ func TestElector(t *testing.T) {
 			t.Error("Failed to become a leader")
 		}
 
-		lock2, err := NewPgAdvisoryLock(2, connectURL)
+		lock2, err := NewPgLeaderLock(2, connectURL)
 		if err != nil {
 			t.Error(err)
 		}
@@ -165,12 +165,12 @@ func TestElector(t *testing.T) {
 
 func TestPrometheusLivenessCheck(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock1, err := NewPgAdvisoryLock(3, connectURL)
+		lock1, err := NewPgLeaderLock(3, connectURL)
 		if err != nil {
 			t.Error(err)
 		}
 		defer lock1.Close()
-		lock2, err := NewPgAdvisoryLock(3, connectURL)
+		lock2, err := NewPgLeaderLock(3, connectURL)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/util/election_test.go
+++ b/pkg/util/election_test.go
@@ -89,9 +89,9 @@ func TestRESTApi(t *testing.T) {
 	}
 }
 
-func TestPgAdvisoryLock(t *testing.T) {
+func TestPgLeaderLock(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock, err := NewPgLeaderLock(1, connectURL)
+		lock, err := NewPgLeaderLock(1, connectURL, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -100,7 +100,7 @@ func TestPgAdvisoryLock(t *testing.T) {
 			t.Error("Couldn't obtain the lock")
 		}
 
-		newLock, err := NewPgLeaderLock(1, connectURL)
+		newLock, err := NewPgLeaderLock(1, connectURL, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func TestPgAdvisoryLock(t *testing.T) {
 
 func TestElector(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock1, err := NewPgLeaderLock(2, connectURL)
+		lock1, err := NewPgLeaderLock(2, connectURL, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -141,7 +141,7 @@ func TestElector(t *testing.T) {
 			t.Error("Failed to become a leader")
 		}
 
-		lock2, err := NewPgLeaderLock(2, connectURL)
+		lock2, err := NewPgLeaderLock(2, connectURL, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -165,12 +165,12 @@ func TestElector(t *testing.T) {
 
 func TestPrometheusLivenessCheck(t *testing.T) {
 	testhelpers.WithDB(t, *testDatabase, testhelpers.NoSuperuser, func(pool *pgxpool.Pool, t testing.TB, connectURL string) {
-		lock1, err := NewPgLeaderLock(3, connectURL)
+		lock1, err := NewPgLeaderLock(3, connectURL, nil)
 		if err != nil {
 			t.Error(err)
 		}
 		defer lock1.Close()
-		lock2, err := NewPgLeaderLock(3, connectURL)
+		lock2, err := NewPgLeaderLock(3, connectURL, nil)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Prior to this commit migration was gated on leader election. This had
three issues:

 1. Multiple writers that did not engage in leader-election would race
    to migrate the database.
 2. Read-only connectors would not check that the database was at a
    valid version
 3. There was nothing preventing the database from being updated out
    from under the connectors.

To fix these issues, this commit introduces a new lease acquired by
every instance of the connector, regardless of whether they read or
write, and gates migration on this lease. Since Every migration is gated
on this one lock, this has two effects:

 1. We guarantee mutual exclusion for migrators.
 2. No migration can happen if there's another connector attached to the
    database.

This means that if a user wishes to update the connector version, they
must first shut down all connectors communicating with the database,
then bring up the connector performing the migration, and finally, only
after the migration has started bring up any other connectors they want
running.