### PR TITLE
Fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,12 @@ services:
     ports:
     - 9090:9090/tcp
     volumes:
-    - ./sample-docker-prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    - ./sample-docker-prometheus:/etc/prometheus/prometheus:ro
   timescale-prometheus-connector:
     build:
       context: .
+    command: -db-ssl-mode=allow
+    restart: on-failure
     depends_on:
     - db
     - prometheus


### PR DESCRIPTION
There were two issues:
1. There's a race-condition between connector-start and database-start:
   if the connector starts too quickly (and it often does) it will try
   to connect to the database before the database is ready and the
   connection will fail. We fix this by having the connector restart on
   failure.
2. Using SSL with postgres on docker requires the user to set up their
   own SSL certificate before starting docker. Since communication
   between the connector and the database in the docker-compose workflow
   is restricted to a single machine we simply tell the connector that
   it need not use SSL.