### PR TITLE
[WIP] Create end-to-end tests

### DIFF
--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+SCRIPT_DIR=$(dirname ${0})
+ROOT_DIR=$(dirname ${SCRIPT_DIR})
+CONNECTOR_URL="localhost:9201"
+PROM_URL="localhost:9090"
+
+docker-compose up &
+
+trap "docker-compose down" EXIT
+
+# the race condition between the connector and the test runner is real
+# to ensure that the connector is actually started, we wait twice hpoing
+# that will be long enough that the connector is really started
+wait_for_connector() {
+    echo "waiting for connector"
+
+    sleep 10
+
+    ${SCRIPT_DIR}/wait-for.sh ${CONNECTOR_URL} -t 60 -- echo "connector may be ready..."
+
+    sleep 10
+
+    ${SCRIPT_DIR}/wait-for.sh ${CONNECTOR_URL} -t 60 -- echo "connector ready"
+}
+
+wait_for_connector
+
+echo "sending write request"
+
+curl -v --request POST \
+    -H "Content-Type: application/x-protobuf" \
+    -H "Content-Encoding: snappy" \
+    -H "X-Prometheus-Remote-Write-Version: 0.1.0" \
+    --data-binary "@${SCRIPT_DIR}/real-dataset.sz" \
+    "${CONNECTOR_URL}/write"
+
+EXIT_CODE=0
+
+compare_connector_and_prom() {
+    QUERY=${1}
+    CONNECTOR_OUTPUT=$(curl "http://${CONNECTOR_URL}/api/v1/query?query=${QUERY}")
+    PROM_OUTPUT=$(curl "http://${PROM_URL}/api/v1/query?query=${QUERY}")
+    echo "ran: ${QUERY}"
+    echo " connector response: ${CONNECTOR_OUTPUT}"
+    echo "prometheus response: ${PROM_OUTPUT}"
+    if [ "${CONNECTOR_OUTPUT}" != "${PROM_OUTPUT}" ]; then
+        echo "mismatched output"
+        EXIT_CODE=1
+    fi
+}
+
+# TODO we need some real tests here, ones that don't return empty data
+compare_connector_and_prom "sum%20by%28mode%29%28demo_cpu_usage_seconds_total%29&time=2020-07-31T17:30:47.182Z"
+
+exit ${EXIT_CODE}

--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# from https://github.com/eficode/wait-for/tree/8d9b4446df0b71275ad1a1c68db0cc2bb6978228
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
This commit adds a script to perform end-to-end tests of the connector using docker-compose. Such tests compare the output of the connector as it would be run by an actual user.

(A current limitation is that we compare our query engine's output against a the output of a prometheus instance that uses our connector as the backend. This means that database errors or connector errors that affect both paths won't be caught by these tests.)

TODO Right now this PR adds an additional version of the real dataset compressed with snappy. This is probably the wrong thing to do: we should either decompress the gz and recompress as snappy dynamically, or just store the data in snappy form.