### PR TITLE
Move router and metrics to api package

### DIFF
--- a/cmd/timescale-prometheus/main.go
+++ b/cmd/timescale-prometheus/main.go
@@ -18,18 +18,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/common/route"
-
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/jamiealquiza/envy"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/timescale/timescale-prometheus/pkg/api"
 	"github.com/timescale/timescale-prometheus/pkg/log"
 	"github.com/timescale/timescale-prometheus/pkg/pgclient"
 	"github.com/timescale/timescale-prometheus/pkg/pgmodel"
-	"github.com/timescale/timescale-prometheus/pkg/query"
 	"github.com/timescale/timescale-prometheus/pkg/util"
 	"github.com/timescale/timescale-prometheus/pkg/version"
 )
@@ -49,121 +45,12 @@ type config struct {
 }
 
 const (
-	tickInterval      = time.Second
 	promLivenessCheck = time.Second
 )
 
 var (
-	leaderGauge = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: util.PromNamespace,
-			Name:      "current_leader",
-			Help:      "Shows current election leader status",
-		},
-	)
-	receivedSamples = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "received_samples_total",
-			Help:      "Total number of received samples.",
-		},
-	)
-	receivedQueries = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "received_queries_total",
-			Help:      "Total number of received queries.",
-		},
-	)
-	sentSamples = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "sent_samples_total",
-			Help:      "Total number of processed samples sent to remote storage.",
-		},
-	)
-	failedSamples = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "failed_samples_total",
-			Help:      "Total number of processed samples which failed on send to remote storage.",
-		},
-	)
-	failedQueries = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "failed_queries_total",
-			Help:      "Total number of queries which failed on send to remote storage.",
-		},
-	)
-	invalidReadReqs = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "invalid_read_requests",
-			Help:      "Total number of remote read requests with invalid metadata.",
-		},
-	)
-	invalidWriteReqs = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Name:      "invalid_write_requests",
-			Help:      "Total number of remote write requests with invalid metadata.",
-		},
-	)
-	sentBatchDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: util.PromNamespace,
-			Name:      "sent_batch_duration_seconds",
-			Help:      "Duration of sample batch send calls to the remote storage.",
-			Buckets:   prometheus.DefBuckets,
-		},
-	)
-	queryBatchDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: util.PromNamespace,
-			Name:      "query_batch_duration_seconds",
-			Help:      "Duration of query batch read calls to the remote storage.",
-			Buckets:   prometheus.DefBuckets,
-		},
-	)
-	httpRequestDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: util.PromNamespace,
-			Name:      "http_request_duration_ms",
-			Help:      "Duration of HTTP request in milliseconds",
-			Buckets:   prometheus.DefBuckets,
-		},
-		[]string{"path"},
-	)
-	ReadQueryLatency = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: util.PromNamespace,
-			Name:      "query_latency_ms",
-			Help:      "Query latency in milliseconds",
-			Buckets:   []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000},
-		},
-		[]string{"query"},
-	)
-	writeThroughput     = util.NewThroughputCalc(tickInterval)
-	elector             *util.Elector
-	lastRequestUnixNano = time.Now().UnixNano()
+	elector *util.Elector
 )
-
-func init() {
-	prometheus.MustRegister(leaderGauge)
-	prometheus.MustRegister(receivedSamples)
-	prometheus.MustRegister(receivedQueries)
-	prometheus.MustRegister(sentSamples)
-	prometheus.MustRegister(failedSamples)
-	prometheus.MustRegister(failedQueries)
-	prometheus.MustRegister(invalidReadReqs)
-	prometheus.MustRegister(invalidWriteReqs)
-	prometheus.MustRegister(sentBatchDuration)
-	prometheus.MustRegister(queryBatchDuration)
-	prometheus.MustRegister(httpRequestDuration)
-	prometheus.MustRegister(ReadQueryLatency)
-	writeThroughput.Start()
-}
 
 func main() {
 	cfg, err := parseFlags()
@@ -181,7 +68,8 @@ func main() {
 	log.Info("msg", "Version:"+version.Version+"; Commit Hash: "+version.CommitHash)
 	log.Info("config", util.MaskPassword(fmt.Sprintf("%+v", cfg)))
 
-	elector, err = initElector(cfg)
+	promMetrics := api.InitMetrics()
+	elector, err = initElector(cfg, promMetrics)
 
 	if err != nil {
 		errStr := fmt.Sprintf("Aborting startup because of elector init error: %s", util.MaskPassword(err.Error()))
@@ -200,7 +88,7 @@ func main() {
 	appVersion := pgmodel.VersionInfo{Version: version.Version, CommitHash: version.CommitHash}
 	// migrate has to happen after elector started
 	if cfg.migrate {
-		err = migrate(&cfg.pgmodelCfg, appVersion)
+		err = migrate(&cfg.pgmodelCfg, appVersion, promMetrics)
 
 		if err != nil {
 			log.Error("msg", fmt.Sprintf("Aborting startup because of migration error: %s", util.MaskPassword(err.Error())))
@@ -221,97 +109,15 @@ func main() {
 
 	// client has to be initiated after migrate since migrate
 	// can change database GUC settings
-	client, err := pgclient.NewClient(&cfg.pgmodelCfg, ReadQueryLatency)
+	client, err := pgclient.NewClient(&cfg.pgmodelCfg)
 	if err != nil {
 		log.Error(util.MaskPassword(err.Error()))
 		os.Exit(1)
 	}
 	defer client.Close()
 
-	cachedMetricNames := prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Namespace: util.PromNamespace,
-		Name:      "metric_name_cache_elements_stored",
-		Help:      "Total number of metric names in the metric name cache.",
-	}, func() float64 {
-		return float64(client.NumCachedMetricNames())
-	})
-
-	metricNamesCacheCap := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: util.PromNamespace,
-		Name:      "metric_name_cache_capacity",
-		Help:      "Maximum number of elements in the metric names cache.",
-	}, func() float64 {
-		return float64(client.MetricNamesCacheCapacity())
-	})
-
-	cachedLabels := prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Namespace: util.PromNamespace,
-		Name:      "label_cache_elements_stored",
-		Help:      "Total number of label-id to label mappings cache.",
-	}, func() float64 {
-		return float64(client.NumCachedLabels())
-	})
-
-	labelsCacheCap := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: util.PromNamespace,
-		Name:      "label_cache_capacity",
-		Help:      "Total number of label-id to label mappings cache.",
-	}, func() float64 {
-		return float64(client.LabelsCacheCapacity())
-	})
-
-	prometheus.MustRegister(cachedMetricNames)
-	prometheus.MustRegister(metricNamesCacheCap)
-	prometheus.MustRegister(cachedLabels)
-	prometheus.MustRegister(labelsCacheCap)
-
-	router := route.New()
-	promMetrics := api.Metrics{
-		LeaderGauge:         leaderGauge,
-		ReceivedSamples:     receivedSamples,
-		FailedSamples:       failedSamples,
-		SentSamples:         sentSamples,
-		SentBatchDuration:   sentBatchDuration,
-		WriteThroughput:     writeThroughput,
-		LastRequestUnixNano: lastRequestUnixNano,
-		QueryBatchDuration:  queryBatchDuration,
-		FailedQueries:       failedQueries,
-		ReceivedQueries:     receivedQueries,
-		CachedMetricNames:   cachedMetricNames,
-		CachedLabels:        cachedLabels,
-		InvalidReadReqs:     invalidReadReqs,
-		InvalidWriteReqs:    invalidWriteReqs,
-	}
-	writeHandler := timeHandler(httpRequestDuration, "write", api.Write(client, elector, &promMetrics))
-	router.Post("/write", writeHandler)
-
-	readHandler := timeHandler(httpRequestDuration, "read", api.Read(client, &promMetrics))
-	router.Get("/read", readHandler)
-	router.Post("/read", readHandler)
-
 	apiConf := &api.Config{AllowedOrigin: cfg.corsOrigin}
-	queryable := client.GetQueryable()
-	queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
-	queryHandler := timeHandler(httpRequestDuration, "query", api.Query(apiConf, queryEngine, queryable))
-	router.Get("/api/v1/query", queryHandler)
-	router.Post("/api/v1/query", queryHandler)
-
-	queryRangeHandler := timeHandler(httpRequestDuration, "query_range", api.QueryRange(apiConf, queryEngine, queryable))
-	router.Get("/api/v1/query_range", queryRangeHandler)
-	router.Post("/api/v1/query_range", queryRangeHandler)
-
-	seriesHandler := timeHandler(httpRequestDuration, "series", api.Series(apiConf, queryable))
-	router.Get("/api/v1/series", seriesHandler)
-	router.Post("/api/v1/series", seriesHandler)
-
-	labelsHandler := timeHandler(httpRequestDuration, "labels", api.Labels(apiConf, queryable))
-	router.Get("/api/v1/labels", labelsHandler)
-	router.Post("/api/v1/labels", labelsHandler)
-
-	labelValuesHandler := timeHandler(httpRequestDuration, "label/:name/values", api.LabelValues(apiConf, queryable))
-	router.Get("/api/v1/label/:name/values", labelValuesHandler)
-
-	router.Get("/healthz", api.Health(client))
+	router := api.GenerateRouter(apiConf, promMetrics, client, elector)
 
 	log.Info("msg", "Starting up...")
 	log.Info("msg", "Listening", "addr", cfg.listenAddr)
@@ -375,7 +181,7 @@ func parseFlags() (*config, error) {
 	return cfg, nil
 }
 
-func initElector(cfg *config) (*util.Elector, error) {
+func initElector(cfg *config, metrics *api.Metrics) (*util.Elector, error) {
 	if cfg.restElection && cfg.haGroupLockID != 0 {
 		return nil, fmt.Errorf("Use either REST or PgAdvisoryLock for the leader election")
 	}
@@ -398,7 +204,7 @@ func initElector(cfg *config) (*util.Elector, error) {
 		go func() {
 			ticker := time.NewTicker(promLivenessCheck)
 			for range ticker.C {
-				lastReq := atomic.LoadInt64(&lastRequestUnixNano)
+				lastReq := atomic.LoadInt64(&metrics.LastRequestUnixNano)
 				scheduledElector.PrometheusLivenessCheck(lastReq, cfg.prometheusTimeout)
 			}
 		}()
@@ -406,19 +212,19 @@ func initElector(cfg *config) (*util.Elector, error) {
 	return &scheduledElector.Elector, nil
 }
 
-func migrate(cfg *pgclient.Config, appVersion pgmodel.VersionInfo) error {
+func migrate(cfg *pgclient.Config, appVersion pgmodel.VersionInfo, metrics *api.Metrics) error {
 	shouldWrite, err := isWriter()
 	if err != nil {
-		leaderGauge.Set(0)
+		metrics.LeaderGauge.Set(0)
 		return fmt.Errorf("isWriter check failed: %w", err)
 	}
 	if !shouldWrite {
-		leaderGauge.Set(0)
+		metrics.LeaderGauge.Set(0)
 		log.Debug("msg", fmt.Sprintf("Election id %v: Instance is not a leader. Won't update", elector.ID()))
 		return nil
 	}
 
-	leaderGauge.Set(1)
+	metrics.LeaderGauge.Set(1)
 	db, err := pgxpool.Connect(context.Background(), cfg.GetConnectionStr())
 	if err != nil {
 		return fmt.Errorf("Error while trying to open DB connection: %w", err)
@@ -450,16 +256,6 @@ func isWriter() (bool, error) {
 		return shouldWrite, err
 	}
 	return true, nil
-}
-
-// timeHandler uses Prometheus histogram to track request time
-func timeHandler(histogramVec prometheus.ObserverVec, path string, handler http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		handler.ServeHTTP(w, r)
-		elapsedMs := time.Since(start).Milliseconds()
-		histogramVec.WithLabelValues(path).Observe(float64(elapsedMs))
-	}
 }
 
 func compileAnchoredRegexString(s string) (*regexp.Regexp, error) {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,9 +1,15 @@
 package api
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/timescale/timescale-prometheus/pkg/util"
 )
+
+const tickInterval = time.Second
+
+var metrics *Metrics
 
 type Metrics struct {
 	// Using the first word in struct to ensure proper alignment in 32-bit systems.
@@ -18,8 +24,114 @@ type Metrics struct {
 	ReceivedQueries     prometheus.Counter
 	FailedQueries       prometheus.Counter
 	QueryBatchDuration  prometheus.Histogram
-	CachedMetricNames   prometheus.CounterFunc
-	CachedLabels        prometheus.CounterFunc
 	InvalidReadReqs     prometheus.Counter
 	InvalidWriteReqs    prometheus.Counter
+	HTTPRequestDuration *prometheus.HistogramVec
+}
+
+func InitMetrics() *Metrics {
+	if metrics != nil {
+		return metrics
+	}
+	metrics = &Metrics{
+		LeaderGauge: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: util.PromNamespace,
+				Name:      "current_leader",
+				Help:      "Shows current election leader status",
+			},
+		),
+		ReceivedSamples: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "received_samples_total",
+				Help:      "Total number of received samples.",
+			},
+		),
+		FailedSamples: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "failed_samples_total",
+				Help:      "Total number of processed samples which failed on send to remote storage.",
+			},
+		),
+		SentSamples: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "sent_samples_total",
+				Help:      "Total number of processed samples sent to remote storage.",
+			},
+		),
+		SentBatchDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: util.PromNamespace,
+				Name:      "sent_batch_duration_seconds",
+				Help:      "Duration of sample batch send calls to the remote storage.",
+				Buckets:   prometheus.DefBuckets,
+			},
+		),
+		WriteThroughput:     util.NewThroughputCalc(tickInterval),
+		LastRequestUnixNano: time.Now().UnixNano(),
+		QueryBatchDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: util.PromNamespace,
+				Name:      "query_batch_duration_seconds",
+				Help:      "Duration of query batch read calls to the remote storage.",
+				Buckets:   prometheus.DefBuckets,
+			},
+		),
+		FailedQueries: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "failed_queries_total",
+				Help:      "Total number of queries which failed on send to remote storage.",
+			},
+		),
+		InvalidReadReqs: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "invalid_read_requests",
+				Help:      "Total number of remote read requests with invalid metadata.",
+			},
+		),
+		InvalidWriteReqs: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "invalid_write_requests",
+				Help:      "Total number of remote write requests with invalid metadata.",
+			},
+		),
+		ReceivedQueries: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: util.PromNamespace,
+				Name:      "received_queries_total",
+				Help:      "Total number of received queries.",
+			},
+		),
+		HTTPRequestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: util.PromNamespace,
+				Name:      "http_request_duration_ms",
+				Help:      "Duration of HTTP request in milliseconds",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{"path"},
+		),
+	}
+	prometheus.MustRegister(
+		metrics.LeaderGauge,
+		metrics.ReceivedSamples,
+		metrics.ReceivedQueries,
+		metrics.SentSamples,
+		metrics.FailedSamples,
+		metrics.FailedQueries,
+		metrics.InvalidReadReqs,
+		metrics.InvalidWriteReqs,
+		metrics.SentBatchDuration,
+		metrics.QueryBatchDuration,
+		metrics.HTTPRequestDuration,
+	)
+	metrics.WriteThroughput.Start()
+
+	return metrics
 }

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/route"
+	"github.com/timescale/timescale-prometheus/pkg/log"
+	"github.com/timescale/timescale-prometheus/pkg/pgclient"
+	"github.com/timescale/timescale-prometheus/pkg/query"
+	"github.com/timescale/timescale-prometheus/pkg/util"
+)
+
+func GenerateRouter(apiConf *Config, metrics *Metrics, client *pgclient.Client, elector *util.Elector) http.Handler {
+	router := route.New()
+	writeHandler := timeHandler(metrics.HTTPRequestDuration, "write", Write(client, elector, metrics))
+	router.Post("/write", writeHandler)
+
+	readHandler := timeHandler(metrics.HTTPRequestDuration, "read", Read(client, metrics))
+	router.Get("/read", readHandler)
+	router.Post("/read", readHandler)
+
+	queryable := client.GetQueryable()
+	queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
+	queryHandler := timeHandler(metrics.HTTPRequestDuration, "query", Query(apiConf, queryEngine, queryable))
+	router.Get("/api/v1/query", queryHandler)
+	router.Post("/api/v1/query", queryHandler)
+
+	queryRangeHandler := timeHandler(metrics.HTTPRequestDuration, "query_range", QueryRange(apiConf, queryEngine, queryable))
+	router.Get("/api/v1/query_range", queryRangeHandler)
+	router.Post("/api/v1/query_range", queryRangeHandler)
+
+	seriesHandler := timeHandler(metrics.HTTPRequestDuration, "series", Series(apiConf, queryable))
+	router.Get("/api/v1/series", seriesHandler)
+	router.Post("/api/v1/series", seriesHandler)
+
+	labelsHandler := timeHandler(metrics.HTTPRequestDuration, "labels", Labels(apiConf, queryable))
+	router.Get("/api/v1/labels", labelsHandler)
+	router.Post("/api/v1/labels", labelsHandler)
+
+	labelValuesHandler := timeHandler(metrics.HTTPRequestDuration, "label/:name/values", LabelValues(apiConf, queryable))
+	router.Get("/api/v1/label/:name/values", labelValuesHandler)
+
+	router.Get("/healthz", Health(client))
+
+	return router
+}
+
+// timeHandler uses Prometheus histogram to track request time
+func timeHandler(histogramVec prometheus.ObserverVec, path string, handler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		handler.ServeHTTP(w, r)
+		elapsedMs := time.Since(start).Milliseconds()
+		histogramVec.WithLabelValues(path).Observe(float64(elapsedMs))
+	}
+}

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type mockHTTPHandler struct {
+	w http.ResponseWriter
+	r *http.Request
+}
+
+func (m *mockHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.w = w
+	m.r = r
+}
+
+type mockObserverVec struct {
+	labelValues []string
+	o           prometheus.Observer
+}
+
+func (m *mockObserverVec) GetMetricWith(_ prometheus.Labels) (prometheus.Observer, error) {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) GetMetricWithLabelValues(lvs ...string) (prometheus.Observer, error) {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) With(_ prometheus.Labels) prometheus.Observer {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) WithLabelValues(l ...string) prometheus.Observer {
+	m.labelValues = l
+	return m.o
+}
+
+func (m *mockObserverVec) CurryWith(_ prometheus.Labels) (prometheus.ObserverVec, error) {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) MustCurryWith(_ prometheus.Labels) prometheus.ObserverVec {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) Describe(_ chan<- *prometheus.Desc) {
+	panic("not implemented")
+}
+
+func (m *mockObserverVec) Collect(_ chan<- prometheus.Metric) {
+	panic("not implemented")
+}
+
+type mockObserver struct {
+	values []float64
+}
+
+func (m *mockObserver) Observe(v float64) {
+	m.values = append(m.values, v)
+}
+
+func TestTimeHandler(t *testing.T) {
+	mockObs := &mockObserver{}
+	mockObserverVec := &mockObserverVec{
+		o: mockObs,
+	}
+
+	mockHandler := &mockHTTPHandler{}
+
+	path := "testpath"
+
+	handler := timeHandler(mockObserverVec, path, mockHandler)
+
+	test := generateHandleTester(t, handler)
+
+	test("GET", strings.NewReader(""))
+
+	if len(mockObs.values) != 1 {
+		t.Errorf("Did not observe elapsed time from request")
+	}
+
+	if mockHandler.r == nil {
+		t.Errorf("Did not call HTTP handler")
+	}
+}
+
+func generateHandleTester(t *testing.T, handleFunc http.Handler) HandleTester {
+	return func(method string, body io.Reader) *httptest.ResponseRecorder {
+		req, err := http.NewRequest(method, "", body)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		req.Header.Set(
+			"Content-Type",
+			"application/x-www-form-urlencoded; param=value",
+		)
+		w := httptest.NewRecorder()
+		handleFunc.ServeHTTP(w, req)
+		return w
+	}
+}

--- a/pkg/pgclient/metrics.go
+++ b/pkg/pgclient/metrics.go
@@ -1,0 +1,59 @@
+package pgclient
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/timescale/timescale-prometheus/pkg/util"
+)
+
+var (
+	cachedMetricNames   prometheus.CounterFunc
+	cachedLabels        prometheus.CounterFunc
+	metricNamesCacheCap prometheus.GaugeFunc
+	labelsCacheCap      prometheus.GaugeFunc
+)
+
+func InitClientMetrics(client *Client) {
+	// Only initialize once.
+	if cachedMetricNames != nil {
+		return
+	}
+
+	cachedMetricNames = prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: util.PromNamespace,
+		Name:      "metric_name_cache_elements_stored",
+		Help:      "Total number of metric names in the metric name cache.",
+	}, func() float64 {
+		return float64(client.NumCachedMetricNames())
+	})
+
+	metricNamesCacheCap = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: util.PromNamespace,
+		Name:      "metric_name_cache_capacity",
+		Help:      "Maximum number of elements in the metric names cache.",
+	}, func() float64 {
+		return float64(client.MetricNamesCacheCapacity())
+	})
+
+	cachedLabels = prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: util.PromNamespace,
+		Name:      "label_cache_elements_stored",
+		Help:      "Total number of label-id to label mappings cache.",
+	}, func() float64 {
+		return float64(client.NumCachedLabels())
+	})
+
+	labelsCacheCap = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: util.PromNamespace,
+		Name:      "label_cache_capacity",
+		Help:      "Total number of label-id to label mappings cache.",
+	}, func() float64 {
+		return float64(client.LabelsCacheCapacity())
+	})
+
+	prometheus.MustRegister(
+		cachedMetricNames,
+		metricNamesCacheCap,
+		cachedLabels,
+		labelsCacheCap,
+	)
+}

--- a/pkg/pgmodel/end_to_end_tests/functions_test.go
+++ b/pkg/pgmodel/end_to_end_tests/functions_test.go
@@ -191,7 +191,7 @@ func TestSQLJsonLabelArray(t *testing.T) {
 					}
 					fingerprintRes := getFingerprintFromJSON(t, jsonRes)
 					if labelSet.Fingerprint() != fingerprintRes {
-						t.Fatalf("Json not equal: got\n%v\nexpected\n%v", string(fingerprintRes), string(jsonOrig))
+						t.Fatalf("Json not equal: got\n%v\nexpected\n%v", fmt.Sprint(fingerprintRes), string(jsonOrig))
 
 					}
 

--- a/pkg/pgmodel/metrics.go
+++ b/pkg/pgmodel/metrics.go
@@ -36,8 +36,10 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(duplicateSamples)
-	prometheus.MustRegister(duplicateWrites)
-	prometheus.MustRegister(decompressCalls)
-	prometheus.MustRegister(decompressEarliest)
+	prometheus.MustRegister(
+		duplicateSamples,
+		duplicateWrites,
+		decompressCalls,
+		decompressEarliest,
+	)
 }


### PR DESCRIPTION
Moving the router and metrics to separate package outside of main package
enables us to reuse it for our end-to-end tests and use the main router for
testing.

Closes #206 