### PR TITLE
Fix leader election

### DIFF
--- a/pkg/util/election.go
+++ b/pkg/util/election.go
@@ -114,7 +114,7 @@ func (se *ScheduledElector) PrometheusLivenessCheck(lastRequestUnixNano int64, t
 	}
 	if leader {
 		if elapsed > timeout {
-			log.Warn("msg", "Prometheus timeout exceeded", "timeout", timeout)
+			log.Warn("msg", "Prometheus timeout exceeded", "timeout", timeout, "elapsed", elapsed)
 			se.pauseScheduledElection()
 			log.Warn("msg", "Scheduled election is paused. Instance is removed from election pool.")
 			err := se.Resign()


### PR DESCRIPTION
The test for eligibility for leader election is based on how long it's been since the client has received a WriteReq from prometheus. Therefore we need to record this time even if the client is not the leader.