### PR TITLE
Ensure fate-sharing for the migration lock

### DIFF
--- a/pkg/pgmodel/end_to_end_tests/main_test.go
+++ b/pkg/pgmodel/end_to_end_tests/main_test.go
@@ -110,7 +110,12 @@ func performMigrate(t testing.TB, connectURL string) {
 		t.Fatal(err)
 	}
 	defer migratePool.Close()
-	err = Migrate(migratePool, pgmodel.VersionInfo{Version: version.Version, CommitHash: "azxtestcommit"})
+	conn, err := migratePool.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	err = Migrate(conn.Conn(), pgmodel.VersionInfo{Version: version.Version, CommitHash: "azxtestcommit"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pgmodel/end_to_end_tests/migrate_test.go
+++ b/pkg/pgmodel/end_to_end_tests/migrate_test.go
@@ -37,12 +37,17 @@ func TestMigrate(t *testing.T) {
 
 		readOnly := testhelpers.GetReadOnlyConnection(t, *testDatabase)
 		defer readOnly.Close()
-		err = pgmodel.CheckDependencies(readOnly, pgmodel.VersionInfo{Version: version.Version})
+		conn, err := readOnly.Acquire(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Release()
+		err = pgmodel.CheckDependencies(conn.Conn(), pgmodel.VersionInfo{Version: version.Version})
 		if err != nil {
 			t.Error(err)
 		}
 
-		err = pgmodel.CheckDependencies(readOnly, pgmodel.VersionInfo{Version: "100.0.0"})
+		err = pgmodel.CheckDependencies(conn.Conn(), pgmodel.VersionInfo{Version: "100.0.0"})
 		if err == nil {
 			t.Errorf("Expected error in CheckDependencies")
 		}
@@ -197,20 +202,25 @@ func TestMigrationLib(t *testing.T) {
 			"idempotent 2",
 		}
 
-		mig := pgmodel.NewMigrator(db, test_migrations.MigrationFiles, testTOC)
+		migrate_to := func(version string) {
+			c, err := db.Acquire(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Release()
+			mig := pgmodel.NewMigrator(c.Conn(), test_migrations.MigrationFiles, testTOC)
 
-		err := mig.Migrate(semver.MustParse("0.1.1"))
-		if err != nil {
-			t.Fatal(err)
+			err = mig.Migrate(semver.MustParse(version))
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 
+		migrate_to("0.1.1")
 		verifyLogs(t, db, expected)
 
 		//does nothing
-		err = mig.Migrate(semver.MustParse("0.1.1"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.1.1")
 		verifyLogs(t, db, expected)
 
 		//migration + idempotent files on update
@@ -219,34 +229,22 @@ func TestMigrationLib(t *testing.T) {
 			"idempotent 1",
 			"idempotent 2")
 
-		err = mig.Migrate(semver.MustParse("0.2.0"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.2.0")
 		verifyLogs(t, db, expected)
 
 		//does nothing, since non-dev and same version as before
-		err = mig.Migrate(semver.MustParse("0.2.0"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.2.0")
 		verifyLogs(t, db, expected)
 
 		//even if no version upgrades, idempotent files apply
 		expected = append(expected,
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.8.0"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.8.0")
 		verifyLogs(t, db, expected)
 
 		//staying on same version does nothing
-		err = mig.Migrate(semver.MustParse("0.8.0"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.8.0")
 		verifyLogs(t, db, expected)
 
 		//migrate two version 0.9.0 and 0.10.0 at once to make sure ordered correctly
@@ -256,30 +254,21 @@ func TestMigrationLib(t *testing.T) {
 			"migration 0.10.0=2",
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.0"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.0")
 		verifyLogs(t, db, expected[0:13])
 
 		//upgrading version, idempotent files apply
 		expected = append(expected,
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.1-dev"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.1-dev")
 		verifyLogs(t, db, expected)
 
 		//even if no version upgrades, idempotent files apply if it's a dev version
 		expected = append(expected,
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.1-dev"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.1-dev")
 		verifyLogs(t, db, expected)
 
 		//now test logic within a release:
@@ -287,19 +276,14 @@ func TestMigrationLib(t *testing.T) {
 			"migration 0.10.1=1",
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.1-dev.1"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.1-dev.1")
 		verifyLogs(t, db, expected[0:20])
+
 		expected = append(expected,
 			"migration 0.10.1=2",
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.1-dev.2"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.1-dev.2")
 		verifyLogs(t, db, expected)
 
 		//test beta tags
@@ -307,10 +291,7 @@ func TestMigrationLib(t *testing.T) {
 			"migration 0.10.2-beta=1",
 			"idempotent 1",
 			"idempotent 2")
-		err = mig.Migrate(semver.MustParse("0.10.2-beta.dev.1"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		migrate_to("0.10.2-beta.dev.1")
 		verifyLogs(t, db, expected)
 	})
 }

--- a/pkg/pgmodel/extension.go
+++ b/pkg/pgmodel/extension.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/timescale/timescale-prometheus/pkg/log"
 	"github.com/timescale/timescale-prometheus/pkg/version"
 )
@@ -23,7 +22,7 @@ var (
 
 // checkExtensionsVersion checks for the correct version and enables the extension if
 // it is at the right version
-func checkExtensionsVersion(conn *pgxpool.Pool) error {
+func checkExtensionsVersion(conn *pgx.Conn) error {
 	if err := checkTimescaleDBVersion(conn); err != nil {
 		return err
 	}
@@ -33,7 +32,7 @@ func checkExtensionsVersion(conn *pgxpool.Pool) error {
 	return nil
 }
 
-func checkTimescaleDBVersion(conn *pgxpool.Pool) error {
+func checkTimescaleDBVersion(conn *pgx.Conn) error {
 	timescaleVersion, isInstalled, err := fetchInstalledExtensionVersion(conn, "timescaledb")
 	if err != nil {
 		return fmt.Errorf("could not get the installed extension version: %w", err)
@@ -60,7 +59,7 @@ func checkTimescaleDBVersion(conn *pgxpool.Pool) error {
 	return nil
 }
 
-func checkTimescalePrometheusExtraVersion(conn *pgxpool.Pool) error {
+func checkTimescalePrometheusExtraVersion(conn *pgx.Conn) error {
 	currentVersion, isInstalled, err := fetchInstalledExtensionVersion(conn, "timescale_prometheus_extra")
 	if err != nil {
 		return fmt.Errorf("could not get the installed extension version: %w", err)
@@ -77,7 +76,7 @@ func checkTimescalePrometheusExtraVersion(conn *pgxpool.Pool) error {
 	return nil
 }
 
-func migrateExtension(conn *pgxpool.Pool) error {
+func migrateExtension(conn *pgx.Conn) error {
 	availableVersions, err := fetchAvailableExtensionVersions(conn)
 	ExtensionIsInstalled = false
 	if err != nil {
@@ -128,7 +127,7 @@ func migrateExtension(conn *pgxpool.Pool) error {
 	return checkExtensionsVersion(conn)
 }
 
-func fetchAvailableExtensionVersions(conn *pgxpool.Pool) (semver.Versions, error) {
+func fetchAvailableExtensionVersions(conn *pgx.Conn) (semver.Versions, error) {
 	var versionStrings []string
 	versions := make(semver.Versions, 0)
 	err := conn.QueryRow(context.Background(),
@@ -153,7 +152,7 @@ func fetchAvailableExtensionVersions(conn *pgxpool.Pool) (semver.Versions, error
 	return versions, nil
 }
 
-func fetchInstalledExtensionVersion(conn *pgxpool.Pool, extensionName string) (semver.Version, bool, error) {
+func fetchInstalledExtensionVersion(conn *pgx.Conn, extensionName string) (semver.Version, bool, error) {
 	var versionString string
 	if err := conn.QueryRow(
 		context.Background(),

--- a/pkg/pgmodel/upgrade_tests/upgrade_test.go
+++ b/pkg/pgmodel/upgrade_tests/upgrade_test.go
@@ -366,11 +366,11 @@ func withNewDBAtCurrentVersion(t testing.TB, DBName string,
 }
 
 func migrateToVersion(t testing.TB, connectURL string, version string, commitHash string) {
-	migratePool, err := pgxpool.Connect(context.Background(), connectURL)
+	migratePool, err := pgx.Connect(context.Background(), connectURL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer migratePool.Close()
+	defer func() { _ = migratePool.Close(context.Background()) }()
 	err = Migrate(migratePool, pgmodel.VersionInfo{Version: version, CommitHash: commitHash})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/util/lock.go
+++ b/pkg/util/lock.go
@@ -228,6 +228,14 @@ func (l *PgAdvisoryLock) getSharedAdvisoryLock() (bool, error) {
 	return l.runLockFunction("SELECT pg_try_advisory_lock_shared($1)")
 }
 
+func (l *PgAdvisoryLock) Conn() (*pgx.Conn, error) {
+	err := l.ensureConnInit()
+	if err != nil {
+		return nil, err
+	}
+	return l.conn, nil
+}
+
 func (l *PgAdvisoryLock) runLockFunction(query string) (bool, error) {
 	err := l.ensureConnInit()
 	if err != nil {


### PR DESCRIPTION
This commit switches migration to use the same connection that holds the migration-lock instead of a separate connection pool. Using a separate pool has a failure mode where the connection holding the lock dies, but the pool remains alive and keeps migrating, potentially allowing a race among multiple migrators. If the same connection is used, the connection dying will also force migration to stop.